### PR TITLE
Fix: parent bindings

### DIFF
--- a/src/core/ManagedObject.ts
+++ b/src/core/ManagedObject.ts
@@ -27,11 +27,14 @@ export enum ManagedState {
     DESTROYING
 };
 
-/** Stack of currently unused managed references, ready for reuse */
-let _freeRefLinks: util.RefLink[] = [];
-
 /** Number of free RefLink instances to keep around */
 const MAX_FREE_REFLINKS = 1000;
+
+/** Stack of currently unused managed references, ready for reuse */
+let _freeRefLinks: util.RefLink[] = [];
+for (let i = 0; i < MAX_FREE_REFLINKS >> 2; i++) {
+    _freeRefLinks[i] = {} as any;
+}
 
 /** Next UID to be assigned to a new managed object */
 let _nextUID = 16;

--- a/src/ui/UIListCellAdapter.ts
+++ b/src/ui/UIListCellAdapter.ts
@@ -26,7 +26,9 @@ export class UIListCellAdapter<TObject extends ManagedObject = ManagedObject>
     })
     implements UIRenderable {
     static preset(presets: UICell.Presets, ...rest: Array<UIRenderableConstructor>): Function {
-        this.presetActiveComponent("cell", UICell.with(presets, ...rest), UIRenderableController);
+        this.presetBindingsFrom(...rest);
+        let p = this.presetActiveComponent("cell", UICell.with(presets, ...rest), UIRenderableController);
+        p.limitBindings("object");
         return super.preset({});
     }
 

--- a/src/ui/UIListController.ts
+++ b/src/ui/UIListController.ts
@@ -27,6 +27,7 @@ export class UIListController extends UIRenderableController {
     static preset(presets: UIListController.Presets,
         ListItemAdapter?: UIListItemAdapter | ((instance: UIListController) => UIListItemAdapter),
         container: ComponentConstructor & (new () => UIContainer) = _defaultContainer): Function {
+        this.presetBindingsFrom(ListItemAdapter as any);
         this.observe(class {
             constructor(public controller: UIListController) { }
             readonly contentMap = new ManagedMap<UIRenderable>();


### PR DESCRIPTION
Mostly an overhaul of the Component class observer to allow preset active components to omit all but a few bindings.