### PR TITLE
Feature: better links

### DIFF
--- a/src/ui/UIComponent.ts
+++ b/src/ui/UIComponent.ts
@@ -106,6 +106,7 @@ export abstract class UIComponent extends Component implements UIRenderable {
         // return preset function
         let f = super.preset(presets, ...rest);
         return function (this: UIContainer) {
+            f.call(this);
             let mixin = style || (styleName && UITheme.current.styles[styleName]);
             if (mixin) {
                 if (this._style === _emptyStyle) this.style = mixin;
@@ -113,7 +114,6 @@ export abstract class UIComponent extends Component implements UIRenderable {
             }
             if (dimensions) this.dimensions = { ...this.dimensions, ...dimensions };
             if (position) this.position = { ...this.position, ...position };
-            return f.call(this);
         };
     }
 

--- a/src/ui/containers/UIContainer.ts
+++ b/src/ui/containers/UIContainer.ts
@@ -14,9 +14,9 @@ export abstract class UIContainer extends UIComponent {
         }
         let f = super.preset(presets, ...rest);
         return function (this: UIContainer) {
+            f.call(this);
             if (layout) this.layout = { ...this.layout, ...layout };
             if (rest.length) this.content.add(...rest.filter(C => !!C).map(C => new C!()));
-            return f.call(this);
         };
     }
 

--- a/src/ui/controls/UIButton.ts
+++ b/src/ui/controls/UIButton.ts
@@ -1,22 +1,14 @@
-import { Application } from "../../app";
 import { Binding, tt } from "../../core";
-import { Stringable, UIComponent } from "../UIComponent";
+import { Stringable } from "../UIComponent";
 import { UITheme } from "../UITheme";
 import { UIControl } from "./UIControl";
 
 /** Represents a button component */
 export class UIButton extends UIControl {
     static preset(presets: UIButton.Presets): Function {
-        if (presets.navigateTo) {
-            let path = presets.navigateTo;
-            if (Binding.isBinding(path)) {
-                throw TypeError("[UIButton] Property navigateTo cannot be bound");
-            }
-            delete presets.navigateTo;
-            presets.onClick = function (this: UIComponent) {
-                let app = this.getCompositeParent(Application);
-                app && app.navigate(path);
-            }
+        // use a 'link' role automatically if `navigateTo` is specified
+        if (presets.navigateTo && !presets.accessibleRole) {
+            presets.accessibleRole = "link";
         }
         return super.preset(presets);
     }
@@ -64,6 +56,9 @@ export class UIButton extends UIControl {
 
     /** Set to true to make the icon appear after the text instead of before */
     iconAfter?: boolean;
+
+    /** Path to navigate to automatically when clicked, if not blank; use `:back` to go back in history */
+    navigateTo?: string;
 }
 
 /** Shortcut for `UIButton` constructor preset with the `button_primary` style set */
@@ -102,7 +97,7 @@ export namespace UIButton {
         iconColor?: string;
         /** Set to true to make the icon appear after the text instead of before */
         iconAfter?: boolean;
-        /** Path to navigate to when clicked (overrides onClick handler), *or* `:back` to go back in history when clicked */
+        /** Path to navigate to automatically when clicked, if not blank; use `:back` to go back in history */
         navigateTo?: string;
         /** Set to true to disable keyboard focus for this button */
         disableKeyboardFocus?: boolean;

--- a/src/ui/controls/UIControl.ts
+++ b/src/ui/controls/UIControl.ts
@@ -19,9 +19,9 @@ export abstract class UIControl extends UIComponent {
         }
         let f = super.preset(presets);
         return function (this: UIControl) {
+            f.call(this);
             if (controlStyle) this.controlStyle = { ...this.controlStyle, ...controlStyle };
             if (textStyle) this.textStyle = { ...this.textStyle, ...textStyle };
-            return f.call(this);
         };
     }
 


### PR DESCRIPTION
Now able to bind `navigateTo`. Actual navigation is handled at platform level instead to deal with cmd-click etc.

Breaking change IF not accompanied by `typescene-webapp` update -- must introduce update there first and start locking dependency to minor version.