### PR TITLE
Improve JSX module output

### DIFF
--- a/JSX/index.d.ts
+++ b/JSX/index.d.ts
@@ -1,3 +1,4 @@
-export * from "./dist";
-import { JSX } from "./dist";
+export * from "../../dist";
+export * from "./dist/JSX";
+import { JSX } from "./dist/JSX";
 export default JSX;

--- a/JSX/index.js
+++ b/JSX/index.js
@@ -1,3 +1,4 @@
-export * from "./dist";
-import { JSX } from "./dist";
+export * from "../../dist";
+export * from "./dist/JSX";
+import { JSX } from "./dist/JSX";
 export default JSX;

--- a/JSX/src/index.ts
+++ b/JSX/src/index.ts
@@ -1,3 +1,0 @@
-export * from "./intrinsics";
-export * from "./JSX";
-

--- a/JSX/src/tsconfig.json
+++ b/JSX/src/tsconfig.json
@@ -13,12 +13,13 @@
     "strict": true,
     "esModuleInterop": true,
     "experimentalDecorators": true,
+    "importHelpers": true,
     "stripInternal": true,
     "noImplicitAny": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true
   },
   "files": [
-    "index.ts"
+    "JSX.ts"
   ]
 }


### PR DESCRIPTION
Make `typescene/JSX` also export everything from `typescene` so there is no need for two import lines in JSX files.