### PR TITLE
Fix: observe form context change events

### DIFF
--- a/src/ui/UIFormContextController.ts
+++ b/src/ui/UIFormContextController.ts
@@ -1,4 +1,5 @@
 import { ComponentEventHandler, managed, ManagedRecord } from "../core";
+import { FormContextChangeEvent } from './containers/UIForm';
 import { UIRenderableController } from "./UIRenderableController";
 
 /**
@@ -15,7 +16,10 @@ export class UIFormContextController extends UIRenderableController {
 UIFormContextController.observe(class {
     constructor(public controller: UIFormContextController) { }
     onFormContextChange() {
-        this.controller.propagateComponentEvent("FormContextChange");
+        if (!this.controller.formContext) return;
+        let event = new FormContextChangeEvent("FormContextChange", this.controller);
+        event.formContext = this.controller.formContext;
+        this.controller.emit(event);
     }
 });
 

--- a/src/ui/UIFormContextController.ts
+++ b/src/ui/UIFormContextController.ts
@@ -1,4 +1,4 @@
-import { ComponentEventHandler, managed, ManagedRecord } from "../core";
+import { ComponentEventHandler, managed, ManagedObject, ManagedRecord } from "../core";
 import { FormContextChangeEvent } from './containers/UIForm';
 import { UIRenderableController } from "./UIRenderableController";
 
@@ -9,7 +9,7 @@ import { UIRenderableController } from "./UIRenderableController";
 export class UIFormContextController extends UIRenderableController {
     /** Form state context; defaults to an empty managed record */
     @managed
-    formContext = new ManagedRecord();
+    formContext: ManagedObject = new ManagedRecord();
 }
 
 // observe to emit event when form context changes

--- a/src/ui/containers/UIForm.ts
+++ b/src/ui/containers/UIForm.ts
@@ -1,10 +1,19 @@
 import { AppActivity } from '../../app';
-import { Component, ComponentEventHandler, managed, ManagedRecord } from '../../core';
+import { Component, ComponentEvent, ComponentEventHandler, managed, ManagedRecord } from '../../core';
 import { UIRenderableConstructor } from '../UIComponent';
 import { UIFormContextController } from '../UIFormContextController';
 import { UIStyle } from '../UIStyle';
 import { UITheme } from '../UITheme';
 import { UICell } from "./UICell";
+
+/**
+ * Event that is emitted when the form context of a `UIForm` or `UIFormContextController` has been changed
+ * @note Despite its name, this event does **not** inherit from `ManagedChangeEvent`.
+ */
+export class FormContextChangeEvent extends ComponentEvent {
+    /** The current form context object */
+    formContext!: ManagedRecord;
+}
 
 /** Style mixin that is automatically applied on each instance */
 const _mixin = UIStyle.create("UIForm", {
@@ -46,9 +55,12 @@ export class UIForm extends UICell {
 
 // observe to emit event when form context changes
 UIForm.observe(class {
-    constructor(public controller: UIForm) { }
+    constructor(public form: UIForm) { }
     onFormContextChange() {
-        this.controller.propagateComponentEvent("FormContextChange");
+        if (!this.form.formContext) return;
+        let event = new FormContextChangeEvent("FormContextChange", this.form);
+        event.formContext = this.form.formContext;
+        this.form.emit(event);
     }
 });
 

--- a/src/ui/containers/UIForm.ts
+++ b/src/ui/containers/UIForm.ts
@@ -1,5 +1,5 @@
 import { AppActivity } from '../../app';
-import { Component, ComponentEvent, ComponentEventHandler, managed, ManagedRecord } from '../../core';
+import { Component, ComponentEvent, ComponentEventHandler, managed, ManagedObject, ManagedRecord } from '../../core';
 import { UIRenderableConstructor } from '../UIComponent';
 import { UIFormContextController } from '../UIFormContextController';
 import { UIStyle } from '../UIStyle';
@@ -12,7 +12,7 @@ import { UICell } from "./UICell";
  */
 export class FormContextChangeEvent extends ComponentEvent {
     /** The current form context object */
-    formContext!: ManagedRecord;
+    formContext!: ManagedObject;
 }
 
 /** Style mixin that is automatically applied on each instance */
@@ -50,7 +50,7 @@ export class UIForm extends UICell {
 
     /** Form state context; defaults to an empty managed record */
     @managed
-    formContext = new ManagedRecord();
+    formContext: ManagedObject = new ManagedRecord();
 }
 
 // observe to emit event when form context changes

--- a/src/ui/controls/UITextField.ts
+++ b/src/ui/controls/UITextField.ts
@@ -1,5 +1,5 @@
-import { CHANGE, managed } from "../../core";
-import { UIForm } from '../containers';
+import { CHANGE, managed, ManagedEvent, onPropertyEvent } from "../../core";
+import { FormContextChangeEvent, UIForm } from '../containers';
 import { Stringable } from '../UIComponent';
 import { UIRenderContext } from '../UIRenderContext';
 import { UITheme } from "../UITheme";
@@ -50,14 +50,16 @@ export class UITextField extends UIControl {
     @managed
     form?: { formContext: any };
 }
-UITextField.observe(class {
+class UITextFieldObserver {
     constructor(public component: UITextField) { }
-    onFormChange() {
-        let ctx = this.component.form &&
-            this.component.form.formContext;
-        if (ctx && this.component.name && this.component.name in ctx) {
-            let value = ctx[this.component.name];
-            this.component.value = value === undefined ? "" : String(value);
+    @onPropertyEvent("form")
+    handleFormUpdate(_form: any, e: ManagedEvent) {
+        if (e instanceof FormContextChangeEvent) {
+            let ctx = e.formContext as any;
+            if (ctx && this.component.name && this.component.name in ctx) {
+                let value = ctx[this.component.name];
+                this.component.value = value === undefined ? "" : String(value);
+            }
         }
     }
     onInput() { this.onChange() }
@@ -76,7 +78,8 @@ UITextField.observe(class {
             }
         }
     }
-});
+}
+UITextField.observe(UITextFieldObserver);
 
 /** Shortcut for `UITextField` constructor preset with the `textfield_borderless` style set */
 export let UIBorderlessTextField = UITextField.with({ style: "textfield_borderless" });

--- a/src/ui/controls/UIToggle.ts
+++ b/src/ui/controls/UIToggle.ts
@@ -1,5 +1,5 @@
-import { managed, ManagedChangeEvent } from "../../core";
-import { UIForm } from '../containers';
+import { CHANGE, managed, ManagedEvent, onPropertyEvent } from "../../core";
+import { FormContextChangeEvent, UIForm } from '../containers';
 import { Stringable } from '../UIComponent';
 import { UIRenderContext } from '../UIRenderContext';
 import { UITheme } from "../UITheme";
@@ -47,14 +47,16 @@ export class UIToggle extends UIControl {
     @managed
     form?: { formContext: any };
 }
-UIToggle.observe(class {
+class UIToggleObserver {
     constructor(public component: UIToggle) { }
-    onFormChange() {
-        let ctx = this.component.form &&
-            this.component.form.formContext;
-        if (ctx && this.component.name && this.component.name in ctx) {
-            let value = ctx[this.component.name];
-            this.component.state = !!value;
+    @onPropertyEvent("form")
+    handleFormUpdate(_form: any, e: ManagedEvent) {
+        if (e instanceof FormContextChangeEvent) {
+            let ctx = e.formContext as any;
+            if (ctx && this.component.name && this.component.name in ctx) {
+                let value = ctx[this.component.name];
+                this.component.state = !!value;
+            }
         }
     }
     onInput() { this.onChange() }
@@ -64,10 +66,11 @@ UIToggle.observe(class {
         if (ctx && this.component.name &&
             ctx[this.component.name] !== !!this.component.state) {
             ctx[this.component.name] = !!this.component.state;
-            ctx.emit(ManagedChangeEvent.CHANGE);
+            ctx.emit(CHANGE);
         }
     }
-});
+}
+UIToggle.observe(UIToggleObserver);
 
 export namespace UIToggle {
     /** UIToggle presets type, for use with `Component.with` */


### PR DESCRIPTION
Input controls rely on observing `form` for changes but the FormContextChange event is not a change event; now observing events properly.