### PR TITLE
Allow use of @observe as a static property decorator

### DIFF
--- a/src/core/ManagedReference.ts
+++ b/src/core/ManagedReference.ts
@@ -132,7 +132,7 @@ export class ManagedReference<T extends ManagedObject = ManagedObject> extends M
 }
 
 /**
- * Managed object property decorator: amend decorated property to turn it into a managed reference to any other managed object (or managed list, map, or reference instance). This allows observers to handle events emitted by the referenced object (see `ManagedObject.observe`).
+ * Managed object property decorator: amend decorated property to turn it into a managed reference to any other managed object (or managed list, map, or reference instance). This allows observers to handle events emitted by the referenced object (see `observe()`).
  *
  * The decorated property immediately becomes undefined when the referenced object is destroyed (see `ManagedObject.managedState`).
  *
@@ -143,7 +143,7 @@ export function managed<T extends ManagedObject>(target: T, propertyKey: any) {
 }
 
 /**
- * Managed object property decorator: amend decorated property to turn it into a managed reference to any other managed object (or managed list, map, or reference instance). This allows observers to handle events emitted by the referenced object (see `ManagedObject.observe`).
+ * Managed object property decorator: amend decorated property to turn it into a managed reference to any other managed object (or managed list, map, or reference instance). This allows observers to handle events emitted by the referenced object (see `observe()`).
  *
  * This asserts a reverse dependency between the referrer and the referenced object.
  * - The reference _must_ point to an instance of `ManagedObject`, and cannot be set to `undefined`.

--- a/test/cases/core/02 ManagedList.ts
+++ b/test/cases/core/02 ManagedList.ts
@@ -1,4 +1,4 @@
-import { managed, ManagedEvent, ManagedList, ManagedObject, ManagedRecord, onPropertyEvent } from "../../../dist";
+import { managed, ManagedEvent, ManagedList, ManagedObject, ManagedRecord, observe, onPropertyEvent } from "../../../dist";
 
 consider("ManagedList", () => {
     it("can create an empty list", t => {
@@ -40,10 +40,10 @@ consider("ManagedList", () => {
         let changes = 0;
         class Group extends ManagedObject {
             @managed list = new ManagedList();
+            @observe static GroupObserver = class {
+                onListChange() { changes++ }
+            }
         }
-        Group.observe(class {
-            onListChange() { changes++ }
-        })
         let g = new Group();
         let o1 = new ManagedObject();
         let o2 = new ManagedObject();


### PR DESCRIPTION
Added use of string as second property to observe() function; now it's possible to use it as a decorator for a static class-type property. This enables access to private properties from observer classes.