### PR TITLE
Streamline compose and observe functions

### DIFF
--- a/src/core/ManagedObject.ts
+++ b/src/core/ManagedObject.ts
@@ -46,12 +46,13 @@ let _nextRefId = 16;
 const RECURSE_EMIT_LIMIT = 4
 
 /** Generic constructor type for ManagedObject, matching both parameterless constructors and those with one or more required parameters */
-export type ManagedObjectConstructor<TObject> = (new (...args: any[]) => TObject) |
+export type ManagedObjectConstructor<TObject extends ManagedObject = ManagedObject> =
+    (new (...args: any[]) => TObject) |
     (new (a: never, b: never, c: never, d: never, e: never, f: never) => TObject);
 
 /** Base class for objects that have their own unique ID, life cycle including active/inactive and destroyed states, and managed references to other instances */
 export class ManagedObject {
-    /** Shortcut to the `observe` function/decorator: add an observer to _all instances_ of this class (i.e. a class that extends `ManagedObject`) and derived classes. */
+    /** Add an observer to _all instances_ of this class and derived classes. Alias for the `observe` function/decorator. */
     static observe<T extends ManagedObject>(
         this: ManagedObjectConstructor<T>,
         Observer: { new(instance: T): any }) {

--- a/test/TestCase.ts
+++ b/test/TestCase.ts
@@ -2,11 +2,13 @@
 
 export type TestCallback = (t: TestCase) => void | Promise<any>;
 
+/** Represents a group of tests, created using `consider` */
 export interface TestGroup {
     name: string;
     cases: TestCase[];
 }
 
+/** Represents a single test case within a test group */
 export class TestCase {
     constructor(
         public readonly groupName: string,
@@ -15,16 +17,57 @@ export class TestCase {
         this._promise = new Promise(resolve => {
             this._resolve = () => {
                 this._resolved = true;
-                if (this._timer) {
-                    clearTimeout(this._timer);
+                if (this._failTimer) {
+                    clearTimeout(this._failTimer);
                 }
                 resolve();
             };
         });
     }
 
+    /** Fails the test case immediately with given message and throws an error */
+    fail(err: string): void;
+    /** Fails the test case immediately with given error and throws the error */
+    fail(err?: any): void;
+    fail(err?: any) {
+        if (typeof err === "string") {
+            err = Error(this._testNameToString("Failure"));
+        }
+        this._error = err || new Error(this._testNameToString("Failure"));
+        this._resolve();
+        throw err;
+    }
+
+    /** Resolves the test case */
+    ok() {
+        this._resolve();
+    }
+
+    /** Fails the test case and throws an error if given value is not falsy; does NOT resolve the test case if the value is true */
+    assert(value: any, comment?: string) {
+        if (!value) {
+            this._error = Error(this._testNameToString(
+                comment || "Assertion failed"));
+            this._resolve();
+            throw Error("Assertion failed");
+        }
+    }
+
+    /** Fails the test case and throws an error if given value is not falsy; resolves the test case if the value is true */
+    test(value: any, comment?: string) {
+        if (!value) this.assert(value, comment || "Test failed");
+        this._resolve();
+    }
+
+    /** Resolves the test case when this method is called n times */
+    count(n: number) {
+        if (!this._count) this._count = 0;
+        if (++this._count! >= n) this._resolve();
+    }
+
+    /** Starts a timer and fails the test case if the case has not been resolved afterwards */
     failOnTimeout(ms = 5000, comment?: string) {
-        this._timer = setTimeout(() => {
+        this._failTimer = setTimeout(() => {
             if (!this._resolved) {
                 let msg = "Timeout" + (comment ? ": " + comment : "");
                 this._error = Error(this._testNameToString(msg));
@@ -33,46 +76,33 @@ export class TestCase {
         }, ms);
     }
 
-    assert(value: any, comment?: string) {
-        if (!value) {
-            this._error = Error(this._testNameToString(
-                comment || "Assertion failed"));
-        }
-        this._resolve();
+    /** Wait for given number of milliseconds (defaults to 100) while test case remains unresolved, and run given callback, if any; also returns a promise, but only one call to `waitAsync` can be active at a time */
+    async waitAsync(ms = 100, callback?: () => void) {
+        if (this._waiting) throw Error("Already waiting once for the same test case");
+        this._waiting = true;
+        await new Promise(r => { setTimeout(r, ms) });
+        this._waiting = false;
+        if (callback) return this._goAsync(callback);
     }
 
-    fail(err: string): void;
-    fail(err?: any): void;
-    fail(err?: any) {
-        if (typeof err === "string") {
-            err = Error(this._testNameToString("Failure"));
-        }
-        this._error = err || new Error(this._testNameToString("Failure"));
-        this._resolve();
-    }
-
-    ok() {
-        this._resolve();
-    }
-
+    /** Runs the test case and awaits the callback and any timeouts */
     async runAsync() {
-        try {
-            if (this.callback) await this.callback(this);
-            else this._resolve();
-        }
-        catch (err) {
-            this._error = err;
-            this._resolve();
-        }
-        if (!this._resolved && !this._timer) {
-            this._error = Error("Case is not resolved");
-            this._resolve();
-        }
-        return this._promise;
+        return this._goAsync(this.callback);
     }
 
+    /** Returns true if the test case has been resolved successfully; returns false if the test case is pending, has failed, or if there was no callback defined */
+    isOK() {
+        return this._resolved && this.callback && !this._error;
+    }
+
+    /** Returns the resulting error, if any */
     getError() {
         return this._error;
+    }
+
+    /** Returns the current count (as incremented by `count()`) */
+    getCount() {
+        return this._count || 0;
     }
 
     private _testNameToString(comment?: string) {
@@ -80,22 +110,42 @@ export class TestCase {
             '"' + this.name + '" (' + this.groupName + ')';
     }
 
+    private async _goAsync(callback?: (t: this) => void) {
+        try {
+            if (callback) await callback(this);
+            else this._resolve();
+        }
+        catch (err) {
+            this._error = err;
+            this._resolve();
+        }
+        if (!this._resolved && !this._failTimer && !this._waiting) {
+            this._error = Error("Case is not resolved");
+            this._resolve();
+        }
+        return this._promise;
+    }
+
     private _promise: Promise<any>;
     private _resolve!: () => void;
     private _resolved?: boolean;
-    private _timer?: any;
+    private _failTimer?: any;
+    private _waiting?: boolean;
     private _error?: any;
+    private _count?: number;
 }
 
 const _tests: TestGroup[] = [];
 let _current: TestGroup | undefined;
 
+/** Creates a named test group, and runs given callback in the context of this group */
 export function consider(name: string, callback: () => void) {
     _tests.push(_current = { name, cases: [] });
     callback();
     _current = undefined;
 }
 
+/** Creates a test case within the current test group (must be run within a callback provided to `consider`) */
 export function it(name: string, callback?: TestCallback) {
     if (!_current) {
         throw Error("Cannot call it(...) outside of consider(...) context");
@@ -103,6 +153,7 @@ export function it(name: string, callback?: TestCallback) {
     _current.cases.push(new TestCase(_current.name, name, callback));
 }
 
+/** Returns the list of created test groups */
 export function getTestGroups() {
     return _tests;
 }

--- a/test/cases/core/01 ManagedObject.ts
+++ b/test/cases/core/01 ManagedObject.ts
@@ -1,14 +1,14 @@
-import { CHANGE, managedChild, ManagedObject } from "../../../dist";
+import { CHANGE, managedChild, ManagedObject, observe } from "../../../dist";
 
 consider("ManagedObject", () => {
     it("can create an instance", t => {
-        t.assert(new ManagedObject());
+        t.test(new ManagedObject());
     })
 
     it("can create a derived class and instance", t => {
         class MyObject extends ManagedObject {}
         let obj = new MyObject;
-        t.assert(obj);
+        t.test(obj);
     })
 
     it("can be activated asynchronously", async t => {
@@ -30,7 +30,7 @@ consider("ManagedObject", () => {
         let p1 = foo1.activateAsync();
         let p2 = foo2.activateAsync();
         await Promise.all([p1, p2]);
-        t.assert(order === "A1A2B1B2");
+        t.test(order === "A1A2B1B2");
     })
 
     it("can emit events and handle them", t => {
@@ -68,15 +68,17 @@ consider("ManagedObject", () => {
         class MyObject extends ManagedObject {
             @managedChild
             child?: MyChildObject;
-        }
-        MyObject.observe(class {
-            constructor(public readonly obj: MyObject) {}
-            ref?: MyChildObject;
-            onChildChange(c: MyChildObject) {
-                if (c) this.ref = c;
-                if (!c && this.ref) t.ok();
+
+            @observe
+            static MyObjectObserver = class {
+                constructor(public readonly obj: MyObject) {}
+                ref?: MyChildObject;
+                onChildChange(c: MyChildObject) {
+                    if (c) this.ref = c;
+                    if (!c && this.ref) t.ok();
+                }
             }
-        })
+        }
         class MyChildObject extends ManagedObject {
             async destroyAsync() {
                 await this.destroyManagedAsync();

--- a/test/cases/core/01a observe.ts
+++ b/test/cases/core/01a observe.ts
@@ -1,0 +1,222 @@
+import { managed, ManagedEvent, ManagedObject, observe, onPropertyEvent, rateLimit } from "../../../dist";
+
+consider("Observers", () => {
+    it("can observe events", t => {
+        class A extends ManagedObject {
+            @observe
+            static AObserver = class {
+                onEvent(e: ManagedEvent) {
+                    if (e.name === "OK") t.count(3);
+                }
+            }
+        }
+        A.observe(class {
+            onEvent(e: ManagedEvent) {
+                if (e.name === "OK") t.count(3);
+            }
+        });
+        observe(A).addEventHandler((_a, e) => {
+            if (e.name === "OK") t.count(3);
+        });
+        new A().emit("OK");
+    })
+
+    it("can observe events (async)", async t => {
+        t.failOnTimeout();
+        class A extends ManagedObject {
+            @observe
+            static AObserver = class {
+                onEventAsync(e: ManagedEvent) {
+                    if (e.name === "OK") t.count(3);
+                }
+            }
+        }
+        A.observe(class {
+            onEventAsync(e: ManagedEvent) {
+                if (e.name === "OK") t.count(3);
+            }
+        });
+        observe(A).addEventHandler((_a, e) => {
+            if (e.name === "OK") t.count(3);
+        }, true);
+        new A().emit("OK");
+        t.assert(!t.getCount(), "Handler called synchronously");
+    })
+
+    it("can observe events (rate limited)", async t => {
+        t.failOnTimeout();
+        let order = "";
+        class A extends ManagedObject { }
+        class AObserver {
+            @rateLimit(100)
+            onEventAsync(e: ManagedEvent) {
+                order += e.name;
+            }
+        }
+        A.observe(AObserver);
+        observe(A).addEventHandler((_a, e) => {
+            order += e.name;
+        }, true, 100);
+        let a = new A();
+        a.emit("1"), a.emit("2");  // trigger 2 immed async
+        order += "A";
+        setTimeout(() => a.emit("3"), 30);  // skip
+        setTimeout(() => a.emit("4"), 40);  // held until ~100ms
+        setTimeout(() => order += "B", 50);
+        setTimeout(() => a.emit("5"), 130);  // skip
+        setTimeout(() => a.emit("6"), 140);  // held until ~200ms
+        setTimeout(() => order += "C", 150);
+        t.waitAsync(300, () => {
+            t.test(order === "A22B44C66");
+        });
+    })
+
+    it("can observe property changes", t => {
+        class A extends ManagedObject {
+            a?: string;
+
+            @observe
+            static AObserver = class {
+                onAChange(v: string) {
+                    if (v === "OK") t.count(3);
+                }
+            }
+        }
+        A.observe(class {
+            onAChange(v: string) {
+                if (v === "OK") t.count(3);
+            }
+        });
+        observe(A).addPropertyChangeHandler("a", (_a, v) => {
+            if (v === "OK") t.count(3);
+        });
+        new A().a = "OK";
+    })
+
+    it("can observe property changes (async)", async t => {
+        t.failOnTimeout();
+        class A extends ManagedObject {
+            a?: string;
+
+            @observe
+            static AObserver = class {
+                onAChangeAsync(v: string) {
+                    if (v === "OK") t.count(3);
+                }
+            }
+        }
+        A.observe(class {
+            onAChangeAsync(v: string) {
+                if (v === "OK") t.count(3);
+            }
+        });
+        observe(A).addPropertyChangeHandler("a", (_a, v) => {
+            if (v === "OK") t.count(3);
+        }, true);
+        new A().a = "OK";
+        t.assert(!t.getCount(), "Handler called synchronously");
+    })
+
+    it("can observe property changes (rate limited)", async t => {
+        let order = "";
+        t.failOnTimeout();
+        class A extends ManagedObject {
+            a?: string;
+        }
+        class AObserver {
+            @rateLimit(100)
+            onAChangeAsync(v: string) {
+                order += v;
+            }
+        }
+        A.observe(AObserver);
+        observe(A).addPropertyChangeHandler("a", (_a, v) => {
+            order += v;
+        }, true, 100);
+        let a = new A();
+        a.a = "1", a.a = "2";  // trigger 2 immed async
+        order += "A";
+        setTimeout(() => a.a = "3", 30);  // skip
+        setTimeout(() => a.a = "4", 40);  // held until ~100ms
+        setTimeout(() => order += "B", 50);
+        setTimeout(() => a.a = "5", 130);  // skip
+        setTimeout(() => a.a = "6", 140);  // held until ~200ms
+        setTimeout(() => order += "C", 150);
+        t.waitAsync(300, () => {
+            t.test(order === "A22B44C66");
+        });
+    })
+
+    it("can observe property events", t => {
+        class B extends ManagedObject {}
+        class A extends ManagedObject {
+            @managed
+            b = new B();
+        }
+        class AObserver {
+            @onPropertyEvent("b")
+            handleBEvent(_v: B, e: ManagedEvent) {
+                if (e.name === "OK") t.count(2);
+            }
+        }
+        A.observe(AObserver);
+        observe(A).addPropertyEventHandler("b", (_b, _v, e) => {
+            if (e.name === "OK") t.count(2);
+        });
+        new A().b.emit("OK");
+    })
+
+    it("can observe property events (async)", async t => {
+        t.failOnTimeout();
+        class B extends ManagedObject {}
+        class A extends ManagedObject {
+            @managed
+            b = new B();
+        }
+        class AObserver {
+            @onPropertyEvent("b")
+            handleBEventAsync(_v: B, e: ManagedEvent) {
+                if (e.name === "OK") t.count(2);
+            }
+        }
+        A.observe(AObserver);
+        observe(A).addPropertyEventHandler("b", (_b, _v, e) => {
+            if (e.name === "OK") t.count(2);
+        }, true);
+        new A().b.emit("OK");
+        t.assert(!t.getCount(), "Handler called synchronously");
+    })
+
+    it("can observe property events (rate limited)", async t => {
+        let order = "";
+        t.failOnTimeout();
+        class B extends ManagedObject {}
+        class A extends ManagedObject {
+            @managed
+            b = new B();
+        }
+        class AObserver {
+            @onPropertyEvent("b")
+            @rateLimit(100)
+            handleBEventAsync(_v: B, e: ManagedEvent) {
+                order += e.name;
+            }
+        }
+        A.observe(AObserver);
+        observe(A).addPropertyEventHandler("b", (_b, _v, e) => {
+            order += e.name;
+        }, true, 100);
+        let a = new A();
+        a.b.emit("1"), a.b.emit("2");  // trigger 2 immed async
+        order += "A";
+        setTimeout(() => a.b.emit("3"), 30);  // skip
+        setTimeout(() => a.b.emit("4"), 40);  // held until ~100ms
+        setTimeout(() => order += "B", 50);
+        setTimeout(() => a.b.emit("5"), 130);  // skip
+        setTimeout(() => a.b.emit("6"), 140);  // held until ~200ms
+        setTimeout(() => order += "C", 150);
+        t.waitAsync(300, () => {
+            t.test(order === "A22B44C66");
+        });
+    })
+})

--- a/test/cases/core/02 ManagedList.ts
+++ b/test/cases/core/02 ManagedList.ts
@@ -1,16 +1,16 @@
-import { managed, ManagedEvent, ManagedList, ManagedObject, ManagedRecord, observe, onPropertyEvent } from "../../../dist";
+import { managed, ManagedList, ManagedObject, ManagedRecord, observe } from "../../../dist";
 
 consider("ManagedList", () => {
     it("can create an empty list", t => {
         let list = new ManagedList();
-        t.assert(list.count === 0);
+        t.test(list.count === 0);
     })
 
     it("can create a non-empty list", t => {
         let record1 = ManagedRecord.create({ foo: "bar" });
         let record2 = ManagedRecord.create({ foo: "baz" });
         let list = new ManagedList(record1, record2);
-        t.assert(list.count === 2 &&
+        t.test(list.count === 2 &&
             list.get(0).foo === "bar" &&
             list.get(1).foo === "baz");
     })
@@ -20,7 +20,7 @@ consider("ManagedList", () => {
         list.add(new ManagedObject());
         list.add(new ManagedObject());
         list.add(new ManagedObject());
-        t.assert(list.count === 3);
+        t.test(list.count === 3);
     })
 
     it("can remove items", t => {
@@ -31,12 +31,11 @@ consider("ManagedList", () => {
         list.add(o1, o2, o3);
         list.remove(o1);
         list.remove(o3);
-        t.assert(list.count === 1 &&
+        t.test(list.count === 1 &&
             list.indexOf(o2) === 0);
     })
 
     it("can be observed", t => {
-        t.failOnTimeout();
         let changes = 0;
         class Group extends ManagedObject {
             @managed list = new ManagedList();
@@ -49,25 +48,18 @@ consider("ManagedList", () => {
         let o2 = new ManagedObject();
         g.list.add(o1, o2);
         g.list.remove(o1);
-        t.assert(changes === 4)
+        t.test(changes === 4)
     })
 
     it("can propagate events", t => {
-        t.failOnTimeout();
-        let events = 0;
         class Group extends ManagedObject {
             @managed list = new ManagedList().propagateEvents();
         }
-        class GroupObserver {
-            @onPropertyEvent("list")
-            handleEvent(_value: any, e: ManagedEvent) {
-                if (e.name === "Foo") events++;
-            }
-        }
-        Group.observe(GroupObserver);
+        observe(Group).addPropertyEventHandler("list", (_group, _list, e) => {
+            if (e.name === "Foo") t.count(3);
+        })
         let g = new Group();
         g.list.add(new ManagedObject, new ManagedObject, new ManagedObject);
         g.list.forEach(item => item.emit("Foo"));
-        t.assert(events === 3);
     })
 })

--- a/test/cases/core/03 ManagedRecord.ts
+++ b/test/cases/core/03 ManagedRecord.ts
@@ -5,12 +5,12 @@ consider("ManagedRecordValidationError", () => {
         let err = new ManagedRecordValidationError("TEST");
         if (!err.isValidationError) t.fail();
         if (err.errors.length !== 1) t.fail();
-        t.assert(/TEST/.test(String(err.errors)));
+        t.test(/TEST/.test(String(err.errors)));
     })
 
     it("can be created using an Error object", t => {
         let err = new ManagedRecordValidationError(Error("TEST"));
-        t.assert(/TEST/.test(String(err.errors)));
+        t.test(/TEST/.test(String(err.errors)));
     })
 
     it("can be created using other validation errors", t => {
@@ -18,6 +18,6 @@ consider("ManagedRecordValidationError", () => {
         let err2 = new ManagedRecordValidationError(
             "TEST", Error("TEST"));
         let result = new ManagedRecordValidationError(err1, err2);
-        t.assert(result.errors.length === 3);
+        t.test(result.errors.length === 3);
     })
 })

--- a/test/run.js
+++ b/test/run.js
@@ -74,21 +74,28 @@ function runAllTests() {
         log += ("-").repeat(80) + "\n";
         groups.forEach(group => {
             log += " 🔍 " + group.name + "\n";
+            let n = 0;
             group.cases.forEach(testCase => {
                 if (!testCase.callback) nUndef++;
-                let err = testCase.getError();
+                if (testCase.isOK()) n++;
                 let dots = Math.max(0, 68 - testCase.name.length);
-                log += "    - " + testCase.name +
-                    " " + (".").repeat(dots) +
-                    (!testCase.callback ? " 💤\n" :
-                        err ? " 💥\n" : " ✅\n");
+                log += (testCase.isOK() ? "    - " : "    * ") +
+                    testCase.name + " " +
+                    (".").repeat(dots) +
+                    (!testCase.callback ? " ⏺\n" :
+                        testCase.getError() ? " 💥\n" : " ✅\n");
             });
-            log += ("-").repeat(80) + "\n";
+            if (n > 0) {
+                let msg = n + " test" + (n > 1 ? "s" : "") + " OK";
+                let dots = Math.max(0, 68 - msg.length);
+                log += "    > " + msg + " " + (".").repeat(dots) + " ✅\n";
+            }
         });
         if (nUndef) {
             log += "Note: " + nUndef + " test(s) are undefined\n";
         }
-        console.log(log);
+        log += ("-").repeat(80) + "\n";
+        console.log(log.replace(/    -.*\n/g, ""));
         if (!errors.length) {
             console.log(" 😁 All tests OK!");
             fs.writeFileSync("test.log", log);


### PR DESCRIPTION
* Make `observe` and `compose` functions more consistent so that they are a better alternative for JS and not just decorators.
* Add more tests for observers (and update the test tooling a bit)