### PR TITLE
Fix UIListCellAdapterEvent propagation

### DIFF
--- a/src/app/ViewComponent.ts
+++ b/src/app/ViewComponent.ts
@@ -1,5 +1,5 @@
-import { logUnhandledException, managedChild, ManagedState } from "../core";
-import { UIComponent, UIComponentEvent, UIRenderable, UIRenderableConstructor, UIRenderContext } from "../ui";
+import { ComponentEvent, logUnhandledException, managedChild, ManagedState } from "../core";
+import { UIComponent, UIRenderable, UIRenderableConstructor, UIRenderContext } from "../ui";
 import { AppComponent } from "./AppComponent";
 import { ViewActivity } from "./ViewActivity";
 
@@ -22,7 +22,7 @@ export class ViewComponent extends AppComponent implements UIRenderable {
 
     async onManagedStateActivatingAsync() {
         super.onManagedStateActivatingAsync();
-        this.propagateChildEvents(UIComponentEvent);
+        this.propagateChildEvents(ComponentEvent);
     }
 
     /**

--- a/src/core/Component.ts
+++ b/src/core/Component.ts
@@ -68,22 +68,30 @@ export type ComponentCtorWithPreset<TComponentCtor extends ComponentConstructor>
     TComponentCtor & { preset(presets: ComponentPresetType<TComponentCtor>): Function };
 
 /** @internal Event that is emitted on (parent) components when a child component is added. The parent component observer responds by setting the `parentObserver` property on the child observer. */
-export class ComponentChildAddedEvent extends ComponentEvent {
+export class ComponentChildAddedEvent extends ManagedEvent {
     constructor(observer: Component.ComponentObserver) {
-        super("ChildComponentAdded", observer.component);
+        super("ChildComponentAdded");
+        this.source = observer.component;
         this.observer = observer;
     }
+
+    /** Source component */
+    source: Component;
 
     /** The observer for the new child component */
     readonly observer: Component.ComponentObserver;
 }
 
 /** @internal Event that is emitted when the composite parent object reference has been set for a component */
-export class CompositeParentChangeEvent extends ComponentEvent {
+export class CompositeParentChangeEvent extends ManagedEvent {
     constructor(component: Component, composite?: Component) {
-        super("CompositeParentChange", component);
+        super("CompositeParentChange");
+        this.source = component;
         this.composite = composite;
     }
+
+    /** Source component */
+    source: Component;
 
     /** The composite parent object reference */
     composite?: Component;

--- a/src/ui/UIComponent.ts
+++ b/src/ui/UIComponent.ts
@@ -14,7 +14,7 @@ let _emptyStyle = new UIStyle();
 export type UIComponentEventHandler<TComponent = UIComponent, TEvent = UIComponentEvent> =
     string | ((this: TComponent, e: TEvent) => void);
 
-/** Event that is emitted on a particular UI component, propagated by all parent UI components. */
+/** Event that is emitted on a particular UI component */
 export class UIComponentEvent<TSource extends UIComponent = UIComponent> extends ComponentEvent {
     constructor(name: string, source: TSource, inner?: ManagedEvent, event?: any) {
         super(name, source, inner);
@@ -120,7 +120,7 @@ export abstract class UIComponent extends Component implements UIRenderable {
     /** Create a new UI component */
     constructor() {
         super();
-        this.propagateChildEvents(UIComponentEvent);
+        this.propagateChildEvents(ComponentEvent);
     }
 
     /** Create and emit a UI event with given name and a reference to this component, as well as an optional platform event; see `Component.propagateComponentEvent` */

--- a/src/ui/UIListController.ts
+++ b/src/ui/UIListController.ts
@@ -1,4 +1,4 @@
-import { Component, ComponentConstructor, ComponentEventHandler, managed, ManagedEvent, ManagedList, ManagedListChangeEvent, ManagedMap, ManagedObject } from "../core";
+import { Component, ComponentConstructor, ComponentEvent, ComponentEventHandler, managed, ManagedEvent, ManagedList, ManagedListChangeEvent, ManagedMap, ManagedObject } from "../core";
 import { UICloseColumn } from "./containers/UIColumn";
 import { UIContainer } from "./containers/UIContainer";
 import { UIComponentEvent, UIRenderable } from "./UIComponent";
@@ -118,7 +118,7 @@ export class UIListController extends UIRenderableController {
     constructor(container?: UIContainer) {
         super(container);
         this.propagateChildEvents(e => {
-            if (e instanceof UIComponentEvent) {
+            if (e instanceof ComponentEvent) {
                 if (e.name === "ArrowUpKeyPress") {
                     if (this.focusPreviousItem()) return;
                     let parentList = this.getParentComponent(UIListController);

--- a/src/ui/UIMenu.ts
+++ b/src/ui/UIMenu.ts
@@ -1,4 +1,4 @@
-import { Component, ComponentEventHandler, managedChild } from "../core";
+import { Component, ComponentEvent, ComponentEventHandler, managedChild } from "../core";
 import { Stringable, UIComponent, UIComponentEvent, UIRenderable } from "./UIComponent";
 import { UIRenderContext } from "./UIRenderContext";
 import { UIMenuBuilder, UITheme } from "./UITheme";
@@ -27,7 +27,7 @@ export class UIMenu extends Component implements UIRenderable {
         }
         this.builder = new UITheme.current.MenuBuilder();
         this.propagateChildEvents(e => {
-            if (e instanceof UIComponentEvent) {
+            if (e instanceof ComponentEvent) {
                 if (e instanceof UIMenuItemSelectedEvent) {
                     this.selected = e.key;
                 }

--- a/src/ui/UIModalController.ts
+++ b/src/ui/UIModalController.ts
@@ -1,6 +1,6 @@
 import { Application } from "../app";
-import { Binding, ComponentConstructor, ComponentEventHandler, managedChild } from "../core";
-import { UIComponent, UIComponentEvent, UIRenderable, UIRenderableConstructor } from "./UIComponent";
+import { Binding, ComponentConstructor, ComponentEvent, ComponentEventHandler, managedChild } from "../core";
+import { UIComponent, UIRenderable, UIRenderableConstructor } from "./UIComponent";
 import { UIRenderableController } from "./UIRenderableController";
 import { UIRenderContext, UIRenderPlacement } from "./UIRenderContext";
 
@@ -19,7 +19,7 @@ export class UIModalController extends UIRenderableController {
         return function (this: UIModalController) {
             f.call(this);
             this.propagateChildEvents(e => {
-                if (e instanceof UIComponentEvent) {
+                if (e instanceof ComponentEvent) {
                     if (e.name === "ShowModal") {
                         let instance = Modal && new Modal();
                         this.modal = instance || undefined;

--- a/src/ui/UIRenderableController.ts
+++ b/src/ui/UIRenderableController.ts
@@ -1,5 +1,5 @@
-import { Component, managed, managedChild } from "../core";
-import { UIComponent, UIComponentEvent, UIRenderable, UIRenderableConstructor } from "./UIComponent";
+import { Component, ComponentEvent, managed, managedChild } from "../core";
+import { UIComponent, UIRenderable, UIRenderableConstructor } from "./UIComponent";
 import { renderContextBinding, UIRenderContext } from "./UIRenderContext";
 
 /** Base class for a controller that wraps around a single renderable component */
@@ -18,7 +18,7 @@ export class UIRenderableController extends Component.with({
     constructor(content?: UIRenderable) {
         super();
         this.content = content;
-        this.propagateChildEvents(UIComponentEvent);
+        this.propagateChildEvents(ComponentEvent);
     }
 
     /** Application render context, propagated from the parent composite object */

--- a/src/ui/UISelectionController.ts
+++ b/src/ui/UISelectionController.ts
@@ -1,5 +1,5 @@
-import { managed } from "../core";
-import { UIComponent, UIComponentEvent, UIRenderable } from "./UIComponent";
+import { Component, ComponentEvent, managed } from "../core";
+import { UIRenderable } from "./UIComponent";
 import { UIRenderableController } from "./UIRenderableController";
 
 /** Renderable wrapper that controls selection state across components, by emitting `Deselect` events for previously selected components upon `Select` events on newly selected components */
@@ -9,7 +9,7 @@ export class UISelectionController extends UIRenderableController {
         super(content);
         this.propagateChildEvents(e => {
             // propagate all UI events, while managing selection state
-            if (e instanceof UIComponentEvent) {
+            if (e instanceof ComponentEvent) {
                 if (e.name === "Select" && e.source !== this.selected) {
                     let old = this.selected;
                     this.selected = e.source;
@@ -25,5 +25,5 @@ export class UISelectionController extends UIRenderableController {
 
     /** Currently selected component, if any */
     @managed
-    selected?: UIComponent;
+    selected?: Component;
 }

--- a/src/ui/containers/UIContainer.ts
+++ b/src/ui/containers/UIContainer.ts
@@ -1,5 +1,5 @@
-import { Binding, Component, managedChild, ManagedList } from "../../core";
-import { UIComponent, UIComponentEvent, UIRenderable, UIRenderableConstructor } from "../UIComponent";
+import { Binding, Component, ComponentEvent, managedChild, ManagedList } from "../../core";
+import { UIComponent, UIRenderable, UIRenderableConstructor } from "../UIComponent";
 import { UIStyle } from "../UIStyle";
 
 /** Represents a UI component that contains other components (abstract) */
@@ -36,7 +36,7 @@ export abstract class UIContainer extends UIComponent {
         super();
         this.content = new ManagedList()
             .restrict<UIRenderable>(Component as any)
-            .propagateEvents(UIComponentEvent);
+            .propagateEvents(ComponentEvent);
         if (content.length) this.content.replace(content);
     }
 


### PR DESCRIPTION
* Don't just propagate `UIComponentEvent` in UI components, but _all_ `ComponentEvent`s.
* Turn `UIListCellAdapterEvent` into a `ComponentEvent`.