### PR TITLE
Fix issue: bound lists are cleared when binding becomes undefined

### DIFF
--- a/src/core/Binding.ts
+++ b/src/core/Binding.ts
@@ -310,6 +310,7 @@ export namespace Binding {
       let value = this._reader.getValue(...arguments); // _v if given
       if (!this._updatedValue || this._lastValue !== value) {
         this._updatedValue = true;
+        let oldValue = this._lastValue;
         this._lastValue = value;
         if (this.parent) {
           // update parent instead
@@ -324,7 +325,7 @@ export namespace Binding {
             if (typeof component[id] !== "function") {
               throw err(ERROR.Binding_NoComponent);
             }
-            component[id](value);
+            component[id](value, oldValue);
           } catch (err) {
             logUnhandledException(err);
           }


### PR DESCRIPTION
There was an issue whereby:
1. A managed list was bound, which was a child list of another object
2. The original property changed to undefined
3. The binding cleared all the items from the bound list, destroying the items in the list

The 'clear' feature exists to clear lists that were automatically populated using array values; however this should obviously not apply if the ManagedList instance was bound directly.

Fixed now.