### PR TITLE
Fix issue where two properties are bound to the same binding

### DIFF
--- a/src/core/Component.ts
+++ b/src/core/Component.ts
@@ -571,7 +571,7 @@ export namespace Component {
         if (!o[p]) {
           let binding = bindings[p];
           let bound = boundObserver.getCompositeBound(binding);
-          if (bound) o[p] = bound.add(component);
+          if (bound && !bound.includes(component)) o[p] = bound.add(component);
         }
       }
 
@@ -669,4 +669,3 @@ function _applyPropertyValue(c: Component, p: string, value: any, old?: any) {
   // otherwise set property value normally
   (c as any)[p] = value;
 }
-

--- a/src/core/ManagedList.ts
+++ b/src/core/ManagedList.ts
@@ -315,9 +315,9 @@ export class ManagedList<T extends ManagedObject = ManagedObject> extends Manage
 
   /** Returns true if given object is currently included in this list */
   includes(target: T) {
+    let managedId = target && target.managedId;
     let ref =
-      target instanceof ManagedObject &&
-      this[HIDDEN.REF_PROPERTY][HIDDEN.MANAGED_LIST_REF_PREFIX + target.managedId];
+      managedId && this[HIDDEN.REF_PROPERTY][HIDDEN.MANAGED_LIST_REF_PREFIX + managedId];
     return !!ref && ref.b === target;
   }
 


### PR DESCRIPTION
There was an issue especially with buttons, where components were unbound and then bound again, but multiple properties are bound to the exact same binding. This leads to an issue "Cannot insert object that is already in this list" because the binding would be bound twice within the same update.

To be merged and released asap.