### PR TITLE
Streamline events for v3.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "balanced-match": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
     "brace-expansion": {
@@ -102,14 +102,14 @@
       }
     },
     "tslib": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.1.tgz",
-      "integrity": "sha512-SgIkNheinmEBgx1IUNirK0TUD4X9yjjBRTqqjggWCU3pUEqIk3/Uwl3yRixYKT6WjQuGiwDv4NomL3wqRCj+CQ=="
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+      "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
     },
     "typescript": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.2.tgz",
-      "integrity": "sha512-e4ERvRV2wb+rRZ/IQeb3jm2VxBsirQLpQhdxplZ2MEzGvDkkMmPglecnNDfSUBivMjP93vRbngYYDQqQ/78bcQ==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.7.tgz",
+      "integrity": "sha512-yi7M4y74SWvYbnazbn8/bmJmX4Zlej39ZOqwG/8dut/MYoSQ119GY9ZFbbGsD4PFZYWxqik/XsP3vk3+W5H3og==",
       "dev": true
     },
     "wrappy": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -107,9 +107,9 @@
       "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
     },
     "typescript": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.7.tgz",
-      "integrity": "sha512-yi7M4y74SWvYbnazbn8/bmJmX4Zlej39ZOqwG/8dut/MYoSQ119GY9ZFbbGsD4PFZYWxqik/XsP3vk3+W5H3og==",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.4.tgz",
+      "integrity": "sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==",
       "dev": true
     },
     "wrappy": {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,6 @@
   "devDependencies": {
     "esm": "^3.2.25",
     "rimraf": "^3.0.2",
-    "typescript": "4.0"
+    "typescript": "*"
   }
 }

--- a/src/app/AppActivityList.ts
+++ b/src/app/AppActivityList.ts
@@ -1,7 +1,14 @@
-import { Component, ComponentConstructor } from "../core/Component";
-import { CHANGE, ManagedCoreEvent } from "../core/ManagedEvent";
-import { ManagedList } from "../core/ManagedList";
-import { managedChild } from "../core/ManagedReference";
+import {
+  Component,
+  ComponentConstructor,
+  CHANGE,
+  ManagedEvent,
+  ManagedCoreEvent,
+  ManagedList,
+  managedChild,
+  delegateEvents,
+  ActionEvent,
+} from "../core";
 import { AppActivity } from "./AppActivity";
 
 /** Component that encapsulates a list of child activities; emits change events when the list changes (propagated from `ManagedList`) and when one of the activities becomes active or inactive */
@@ -21,9 +28,10 @@ export class AppActivityList extends Component {
     super();
     this.$list = new ManagedList().restrict(AppActivity);
 
-    // propagate list events, active/inactive
-    this.propagateChildEvents();
+    // propagate events from components in the list to the list itself,
+    // so that they can be delegated from there
     this.$list.propagateEvents(e => {
+      if (e instanceof ActionEvent) return e;
       if (e === ManagedCoreEvent.ACTIVE || e === ManagedCoreEvent.INACTIVE) {
         return CHANGE;
       }
@@ -71,7 +79,13 @@ export class AppActivityList extends Component {
     return this.$list.toArray();
   }
 
+  /** Re-emits given event on this component; called for each event that is emitted by the encapsulated list (which also propagates events of type `ActionEvent` from all contained activities) */
+  delegateEvent(e: ManagedEvent) {
+    this.emit(e);
+  }
+
   /** The encapsulated list itself */
+  @delegateEvents
   @managedChild
   private $list!: ManagedList<AppActivity>;
 }

--- a/src/app/Application.ts
+++ b/src/app/Application.ts
@@ -6,6 +6,7 @@ import {
   ManagedList,
   ManagedService,
   ManagedCoreEvent,
+  delegateEvents,
 } from "../core";
 import { UIRenderContext } from "../ui";
 import { AppActivationContext } from "./AppActivationContext";
@@ -69,6 +70,7 @@ export class Application extends Component {
   readonly name: string = "Application";
 
   /** List of root activities, as child components */
+  @delegateEvents
   @managedChild
   activities?: AppActivityList;
 

--- a/src/app/ViewActivity.ts
+++ b/src/app/ViewActivity.ts
@@ -145,7 +145,9 @@ export class ViewActivity extends AppActivity implements UIRenderable {
 
     // create a singleton activity constructor with event handler
     class SingletonActivity extends DialogViewActivity.with(View) {}
-    if (eventHandler) SingletonActivity.addEventHandler(eventHandler);
+    if (eventHandler) {
+      SingletonActivity.prototype.delegateEvent = eventHandler;
+    }
     let activity: ViewActivity = new SingletonActivity();
     return app.showViewActivityAsync(activity);
   }

--- a/src/app/ViewActivity.ts
+++ b/src/app/ViewActivity.ts
@@ -1,4 +1,6 @@
 import {
+  ComponentEvent,
+  delegateEvents,
   logUnhandledException,
   managed,
   managedChild,
@@ -8,7 +10,6 @@ import {
 import { err, ERROR } from "../errors";
 import {
   UIComponent,
-  UIComponentEvent,
   UIRenderable,
   UIRenderableConstructor,
   UIRenderContext,
@@ -48,18 +49,8 @@ export class ViewActivity extends AppActivity implements UIRenderable {
     return super.preset(presets);
   }
 
-  /** Create a new (inactive) view activity with given name and path */
-  constructor(name?: string, path?: string) {
-    super(name, path);
-    this.propagateChildEvents(e => {
-      if (e instanceof UIComponentEvent && e.name === "FocusIn") {
-        if (!this.firstFocused) this.firstFocused = e.source;
-        this.lastFocused = e.source;
-      }
-    });
-  }
-
   /** The root component that makes up the content for this view, as a child component */
+  @delegateEvents
   @managedChild
   view?: UIRenderable;
 
@@ -120,6 +111,14 @@ export class ViewActivity extends AppActivity implements UIRenderable {
     else this.lastFocused && this.lastFocused.requestFocus();
   }
 
+  /** Handle FocusIn UI event, remember first/last focused component */
+  protected onFocusIn(e: ComponentEvent) {
+    if (e.source instanceof UIComponent) {
+      if (!this.firstFocused) this.firstFocused = e.source;
+      this.lastFocused = e.source;
+    }
+  }
+
   /** The UI component that was focused first, if any */
   @managed
   firstFocused?: UIComponent;
@@ -129,13 +128,13 @@ export class ViewActivity extends AppActivity implements UIRenderable {
   lastFocused?: UIComponent;
 
   /**
-   * Create an instance of given view component, wrapped in a singleton dialog view activity, and adds it to the application to be displayed immediately.
+   * Create an instance of given view component, wrapped in a singleton dialog view activity, and adds it to the application to be displayed immediately. The activity responds to the CloseModal event by destroying the activity, which removes the view as well.
    * @param View
    *  A view component constructor
    * @param eventHandler
-   *  A function that is invoked for all events that are emitted by the view; if no function is specified, only the `CloseModal` event is handled (emitted e.g. when clicking outside of the modal view area) by destroying the view activity instance.
+   *  A function that is invoked for all events that are emitted by the view
    * @returns A promise that resolves to the view _activity_ instance after it has been activated.
-   * @note Use to the `Application.showViewActivityAsync` method to show a view that is already encapsulated in an activity instance.
+   * @note Use the `Application.showViewActivityAsync` method, or reference an activity using a managed child property to show a view that is already encapsulated in an activity.
    */
   showDialogAsync(
     View: UIRenderableConstructor,
@@ -145,12 +144,8 @@ export class ViewActivity extends AppActivity implements UIRenderable {
     if (!app) throw err(ERROR.ViewActivity_NoApplication);
 
     // create a singleton activity constructor with event handler
-    class SingletonActivity extends DialogViewActivity.with(View) {
-      constructor() {
-        super();
-        if (eventHandler) this.propagateChildEvents(eventHandler);
-      }
-    }
+    class SingletonActivity extends DialogViewActivity.with(View) {}
+    if (eventHandler) SingletonActivity.addEventHandler(eventHandler);
     let activity: ViewActivity = new SingletonActivity();
     return app.showViewActivityAsync(activity);
   }
@@ -267,9 +262,12 @@ export class DialogViewActivity extends ViewActivity {
     super();
     this.placement = UIRenderPlacement.DIALOG;
     this.modalShadeOpacity = UITheme.current.modalDialogShadeOpacity;
-    this.propagateChildEvents(e => {
-      if (e.name === "CloseModal") this.destroyAsync();
-    });
+  }
+
+  /** Handle CloseModal event by destroying this activity; stops propagation of the event */
+  protected onCloseModal() {
+    this.destroyAsync();
+    return true;
   }
 }
 

--- a/src/core/Component.ts
+++ b/src/core/Component.ts
@@ -1,5 +1,5 @@
 import { err, ERROR } from "../errors";
-import { HIDDEN } from "./util";
+import { HIDDEN, defineChainableProperty, exceptionHandler } from "./util";
 import { Binding } from "./Binding";
 import { ManagedEvent, ManagedParentChangeEvent, ManagedCoreEvent } from "./ManagedEvent";
 import { ManagedList } from "./ManagedList";
@@ -19,7 +19,7 @@ export class ComponentEvent<TComponent extends Component = Component> extends Ma
   /** Source component */
   source: TComponent;
 
-  /** Encapsulated event (i.e. propagated event if this event was emitted by `Component.propagateComponentEvent`) */
+  /** Encapsulated event, if the event was originally of a different type */
   inner?: ManagedEvent;
 }
 
@@ -27,6 +27,18 @@ export class ComponentEvent<TComponent extends Component = Component> extends Ma
 export type ComponentEventHandler<TComponent = Component, TEvent = ComponentEvent> =
   | string
   | ((this: TComponent, e: TEvent) => void);
+
+/**
+ * Component-specific event that represents the result of a user action, with reference to the source component and optional additional context. Actions are intended to be handled by parent components, or propagated further up the component hierarchy by re-emitting them (default behavior for `Component.delegateEvent`).
+ * @note This event type is used when handling events using _preset_ components, using e.g. `{ "onClick": "EventName" }`. The method `Component.emitAction()` can also be used to emit action events.
+ */
+export class ActionEvent<
+  TComponent extends Component = Component,
+  TContext extends ManagedObject = ManagedObject
+> extends ComponentEvent<TComponent> {
+  /** Action context (if different from `source` component) */
+  context?: TContext;
+}
 
 /** Generic constructor type for Component classes */
 export type ComponentConstructor<TComponent extends Component = Component> = new (
@@ -142,12 +154,13 @@ export class Component extends ManagedObject {
   }
 
   /**
-   * Add bindings, components, and event handlers from given presets to the current component constructor. This method is called by `Component.with` with the same arguments.
+   * Add bindings, components, and event handlers from given presets to the current component constructor. This method is called by `Component.with` with the same arguments, and should not be called directly.
    * Component classes may override this method and return the result of `super.preset(...)`, to add further presets and bindings using static methods on this component class.
    * @returns A function (*must* be typed as `Function` even in derived classes) that is called by the constructor for each new instance, to apply remaining values from the preset object to the component object that is passed through `this`.
    */
   static preset(presets: object, ...rest: unknown[]): Function {
     // take and apply bindings and components to the constructor already
+    let eventActions: { [eventName: string]: string } | undefined;
     let eventHandlers:
       | { [eventName: string]: (this: Component, e: any) => void }
       | undefined;
@@ -157,16 +170,18 @@ export class Component extends ManagedObject {
         // add binding to constructor and remove from presets
         this.presetBinding(p, v);
         delete (presets as any)[p];
-      } else if (
-        v &&
-        p[0] === "o" &&
-        p[1] === "n" &&
-        (p.charCodeAt(2) < 97 || p.charCodeAt(2) > 122)
-      ) {
-        // add event handlers to object
-        if (!eventHandlers) eventHandlers = Object.create(null);
-        eventHandlers![p.slice(2)] =
-          typeof v === "function" ? v : _makeEventHandler(String(v));
+      } else if (v && p[0] === "o" && p[1] === "n" && (p[2] < "a" || p[2] > "z")) {
+        // add action to propagate (event name starting with capital letter)
+        if (typeof v === "string" && (v[0] < "a" || v[0] > "z")) {
+          if (v[0] === "+") v = v.slice(1);
+          if (!eventActions) eventActions = Object.create(null);
+          eventActions![p.slice(2)] = v;
+        } else {
+          // add event handler directly
+          if (!eventHandlers) eventHandlers = Object.create(null);
+          eventHandlers![p.slice(2)] =
+            typeof v === "function" ? v : _makeEventHandler(String(v));
+        }
         delete (presets as any)[p];
       } else if (typeof v === "function" && v.prototype instanceof Component) {
         // add bindings for component constructor
@@ -177,6 +192,12 @@ export class Component extends ManagedObject {
     if (rest.length) this.presetBindingsFrom(...(rest as any));
 
     // add event handlers, if any
+    if (eventActions) {
+      this.addEventHandler(function (e) {
+        let actionName = eventActions![e.name];
+        if (actionName) this.emitAction(actionName);
+      });
+    }
     if (eventHandlers) {
       this.addEventHandler(function (e) {
         let h = eventHandlers![e.name];
@@ -266,6 +287,22 @@ export class Component extends ManagedObject {
     return false;
   }
 
+  /**
+   * Delegate given event by invoking a matching handler method, prefixing the event name with 'on'. For example, events with name 'Submit' can be handled by a method named `onSubmit()`. The handler method is called with the same arguments as this method, and should return `true` if the event has been handled.
+   * Additionally, if the event is of type `ActionEvent`, and if a handler method was not found, or if it did not return `true`, then the event is re-emitted on the component itself (also known as 'propagated') -- allowing it to be handled by other components, usually by a parent component.
+   * This method is used as a default handler for `@delegateEvents`. It can be overridden if events should be handled differently in specific cases. A return value other than `true` indicates that the event is neither handled by a method that returned `true` itself, nor propagated.
+   * @note In case the event name starts with a lowercase letter (a-z), the handler method should still include a capital letter (e.g. `onDoSomething()` for an event named 'doSomething'). However, it is _not_ recommended to use event names that start with lowercase letters.
+   */
+  protected delegateEvent(e: ManagedEvent, propertyName: string): true | void {
+    let method = (this as any)[_makeMethodName(e.name)];
+    let handled = typeof method === "function" && method.call(this, e, propertyName);
+    if (handled === true) return true;
+    if (e instanceof ActionEvent) {
+      this.emit(e);
+      return true;
+    }
+  }
+
   /** Returns the current parent component. If a class reference is specified, finds the nearest parent of given type. See `@managedChild` decorator. */
   getParentComponent<TParent extends Component = Component>(
     ParentClass?: ComponentConstructor<TParent>
@@ -287,9 +324,21 @@ export class Component extends ManagedObject {
   }
 
   /**
+   * Emit an action event (see `ActionEvent`), to signal the result of a user action that should be handled by a parent component.
+   * @note The event is frozen using `ManagedEvent.freeze()` so that its properties cannot be modified even if the event is reused by parent component(s).
+   */
+  emitAction(name: string, inner?: ManagedEvent, context?: ManagedObject) {
+    let event = new ActionEvent(name, this, inner);
+    event.context = context;
+    this.emit(event.freeze());
+  }
+
+  /**
+   * @deprecated in v3.1
+   * NOTE: This method will be deprecated in favor of calling `emit` directly. Its name is confusing and after streamlining other parts it will serve no further purpose.
    * Create and emit an event with given name, a reference to this component, and an optional inner (propagated) event. The base implementation emits a plain `ComponentEvent`, but this method may be overridden to emit other events.
    * @note If the component is already in the 'destroyed' state (see `ManagedObject.managedState`), then no event is emitted and this method returns immediately.
-   * @note This method is used by classes created using `Component.with` if an event handler is specified using the `{ ... onEventName: "+OtherEvent" }` pattern.
+   * @note This method is used by classes created using `Component.with` if an event handler is specified using the `{ ... onEventName: "OtherEvent" }` pattern.
    */
   propagateComponentEvent(name: string, inner?: ManagedEvent) {
     if (!this.managedState) return;
@@ -616,10 +665,12 @@ export namespace Component {
   Component.addObserver(ComponentObserver);
 }
 
-/** Helper function to make an event handler from a preset string property */
-function _makeEventHandler(handler: string) {
-  if (handler.slice(-2) === "()") {
-    let callMethodName = handler.slice(0, -2);
+/** Helper function to make an event handler from a preset string property -- DEPRECATED use only */
+function _makeEventHandler(name: string) {
+  if (name.slice(-2) === "()") {
+    // Invoking event handlers on bound parent components by name
+    // was a bad idea and will not be supported anymore.
+    let callMethodName = name.slice(0, -2);
     return function (this: Component, e: ManagedEvent) {
       let composite: Component | undefined = this.getBoundParentComponent();
       while (composite) {
@@ -629,14 +680,8 @@ function _makeEventHandler(handler: string) {
       }
       throw err(ERROR.Component_NotAHandler, callMethodName);
     };
-  } else if (handler[0] === "+") {
-    let emitName = handler.slice(1);
-    return function (this: Component, e: ManagedEvent) {
-      this.propagateComponentEvent(emitName, e);
-    };
-  } else {
-    throw err(ERROR.Component_InvalidEventHandler, handler);
   }
+  throw err(ERROR.Component_InvalidEventHandler, name);
 }
 
 /** Simple ManagedObject class that encapsulates a single value, used below */
@@ -649,7 +694,35 @@ class ManagedValueObject<T> extends ManagedObject {
   }
 }
 
-/** Helper method to update a component property with given value, with some additional logic for managed lists */
+/** Property decorator: observe events on objects that are referenced by this property. For each event, the `delegateEvent()` method is invoked on the containing component. A default implementation is provided as `Component.delegateEvent`, but this method can be overridden by each subclass.
+ * @note This decorator _must_ be combined with either `@managed`, `@managedChild`, or `@service`
+ * @decorator
+ */
+export function delegateEvents(targetPrototype: Component, propertyKey: string) {
+  defineChainableProperty(
+    targetPrototype,
+    propertyKey as string,
+    false,
+    (obj: any, _name, next) => {
+      let handling: ManagedEvent | undefined;
+      return (value, event, topHandler) => {
+        next && next(value, event, topHandler);
+        if (event) {
+          // received an event from the referenced object, delegate synchronously
+          if (handling === event || !obj[HIDDEN.STATE_PROPERTY]) return;
+          try {
+            obj.delegateEvent((handling = event), propertyKey);
+            handling = undefined;
+          } catch (err) {
+            exceptionHandler(err);
+          }
+        }
+      };
+    }
+  );
+}
+
+/** Helper function to update a component property with given value, with some additional logic for managed lists */
 function _applyPropertyValue(c: Component, p: string, value: any, old?: any) {
   let cur = (c as any)[p];
   if (cur && cur instanceof ManagedList) {
@@ -668,4 +741,14 @@ function _applyPropertyValue(c: Component, p: string, value: any, old?: any) {
   }
   // otherwise set property value normally
   (c as any)[p] = value;
+}
+
+/** Helper function to compose a handler method name from an event name, possibly capitalizing its first letter */
+function _makeMethodName(name: string) {
+  return (
+    "on" +
+    (name[0] < "a" || name[0] > "z"
+      ? name
+      : String.fromCharCode(name.charCodeAt(0) - (97 /* a */ - 65) /* A */) + name.slice(1))
+  );
 }

--- a/src/core/Component.ts
+++ b/src/core/Component.ts
@@ -293,7 +293,7 @@ export class Component extends ManagedObject {
    * This method is used as a default handler for `@delegateEvents`. It can be overridden if events should be handled differently in specific cases. A return value other than `true` indicates that the event is neither handled by a method that returned `true` itself, nor propagated.
    * @note In case the event name starts with a lowercase letter (a-z), the handler method should still include a capital letter (e.g. `onDoSomething()` for an event named 'doSomething'). However, it is _not_ recommended to use event names that start with lowercase letters.
    */
-  protected delegateEvent(e: ManagedEvent, propertyName: string): true | void {
+  protected delegateEvent(e: ManagedEvent, propertyName: string): boolean | void {
     let method = (this as any)[_makeMethodName(e.name)];
     let handled = typeof method === "function" && method.call(this, e, propertyName);
     if (handled === true) return true;

--- a/src/core/ManagedEvent.ts
+++ b/src/core/ManagedEvent.ts
@@ -1,6 +1,6 @@
-import { ManagedList } from "./ManagedList";
-import { ManagedMap } from "./ManagedMap";
-import { ManagedObject } from "./ManagedObject";
+import type { ManagedList } from "./ManagedList";
+import type { ManagedMap } from "./ManagedMap";
+import type { ManagedObject } from "./ManagedObject";
 
 /**
  * Event that can be emitted on a managed object, component, list/map, or reference, and can be handled by observers or by objects that reference the emitting object.
@@ -24,7 +24,7 @@ export class ManagedEvent {
   }
 }
 
-/** Core event that is _not propagated_ by default (see `ManagedObject.propagateChildEvents`) */
+/** Status events, specific to a single object */
 export class ManagedCoreEvent extends ManagedEvent {
   /** Returns true if given event is a core event */
   static isCoreEvent(event: ManagedEvent): event is ManagedCoreEvent {

--- a/src/core/ManagedList.ts
+++ b/src/core/ManagedList.ts
@@ -7,8 +7,8 @@ import {
 } from "./ManagedEvent";
 import { ManagedObject, ManagedObjectConstructor } from "./ManagedObject";
 import { shadowObservable } from "./observe";
-import * as util from "./util";
 import { HIDDEN } from "./util";
+import * as util from "./util";
 
 // really simple shim for Symbol.iterator in older browsers, only good for ManagedList below
 if (typeof Symbol !== "function") {
@@ -50,13 +50,8 @@ export class ManagedList<T extends ManagedObject = ManagedObject> extends Manage
   propagateEvents(
     ...types: Array<ManagedEvent | { new (...args: any[]): ManagedEvent }>
   ): this;
-  propagateEvents() {
-    this.propagateChildEvents.apply(this, arguments as any);
-    Object.defineProperty(this, HIDDEN.NONCHILD_EVENT_HANDLER, {
-      configurable: true,
-      enumerable: false,
-      value: this[HIDDEN.CHILD_EVENT_HANDLER],
-    });
+  propagateEvents(...types: any[]) {
+    util.propagateEvents(this, false, ...types);
     return this;
   }
 

--- a/src/core/ManagedMap.ts
+++ b/src/core/ManagedMap.ts
@@ -6,6 +6,7 @@ import {
 } from "./ManagedEvent";
 import { ManagedObject, ManagedObjectConstructor } from "./ManagedObject";
 import { HIDDEN } from "./util";
+import * as util from "./util";
 
 /** Represents an _unordered_ list of managed objects that are indexed using unique key strings */
 export class ManagedMap<T extends ManagedObject = ManagedObject> extends ManagedObject {
@@ -30,13 +31,8 @@ export class ManagedMap<T extends ManagedObject = ManagedObject> extends Managed
   propagateEvents(
     ...types: Array<ManagedEvent | { new (...args: any[]): ManagedEvent }>
   ): this;
-  propagateEvents() {
-    this.propagateChildEvents.apply(this, arguments as any);
-    Object.defineProperty(this, HIDDEN.NONCHILD_EVENT_HANDLER, {
-      configurable: true,
-      enumerable: false,
-      value: this[HIDDEN.CHILD_EVENT_HANDLER],
-    });
+  propagateEvents(...types: any[]) {
+    util.propagateEvents(this, false, ...types);
     return this;
   }
 

--- a/src/core/ManagedReference.ts
+++ b/src/core/ManagedReference.ts
@@ -2,6 +2,7 @@ import { err, ERROR } from "../errors";
 import { ManagedChangeEvent, ManagedEvent } from "./ManagedEvent";
 import { ManagedObject, ManagedObjectConstructor } from "./ManagedObject";
 import { HIDDEN } from "./util";
+import * as util from "./util";
 
 /** Property ID for the single reference link used by ManagedReference */
 const REF_PROP_ID = HIDDEN.PROPERTY_ID_PREFIX + "*ref";
@@ -17,7 +18,7 @@ export class ManagedReference<
   }
 
   /**
-   * Propagate events from referenced objects by emitting the same events on the reference instance itself.
+   * Propagate events from referenced objects by emitting the same events on the `ManagedReference` instance itself.
    * If a function is specified, the function can be used to transform one event to one or more others, or stop propagation if the function returns undefined. The function is called with the event itself as its only argument.
    * @note Calling this method a second time _replaces_ the current propagation rule/function.
    */
@@ -25,20 +26,15 @@ export class ManagedReference<
     f?: (this: this, e: ManagedEvent) => ManagedEvent | ManagedEvent[] | undefined | void
   ): this;
   /**
-   * Propagate events from referenced objects by emitting the same events on the reference instance itself.
+   * Propagate events from referenced objects by emitting the same events on the `ManagedReference` instance itself.
    * If one or more event classes are specified, only events that extend given event types are propagated.
    * @note Calling this method a second time _replaces_ the current propagation rule/function.
    */
   propagateEvents(
     ...types: Array<ManagedEvent | { new (...args: any[]): ManagedEvent }>
   ): this;
-  propagateEvents(): this {
-    this.propagateChildEvents.apply(this, arguments as any);
-    Object.defineProperty(this, HIDDEN.NONCHILD_EVENT_HANDLER, {
-      configurable: true,
-      enumerable: false,
-      value: this[HIDDEN.CHILD_EVENT_HANDLER],
-    });
+  propagateEvents(...types: any[]) {
+    util.propagateEvents(this, false, ...types);
     return this;
   }
 

--- a/src/core/UnhandledErrorEmitter.ts
+++ b/src/core/UnhandledErrorEmitter.ts
@@ -15,7 +15,7 @@ export class UnhandledErrorEvent extends ManagedEvent {
 
 /**
  * Singleton managed object class that logs errors and emits an `UnhandledErrorEvent` for otherwise unhandled exceptions.
- * The (single) instance of this class can be observed to capture errors as `UnhandledErrorEvent` events, to handle errors in different ways
+ * This class can be observed to capture errors, e.g. using `ManagedObject.addEventHandler()`.
  */
 export class UnhandledErrorEmitter extends ManagedObject {
   /** Log and emit given error */

--- a/src/core/observe.ts
+++ b/src/core/observe.ts
@@ -20,8 +20,8 @@ const OBS_UID_PROP = "^o:uid";
 const RESOLVED = Promise.resolve();
 
 /**
- * Add the decorated observer to _all instances_ of the target class and derived classes. A new observer (instance of given observer class) is created for each target instance, and observed properties are amended with dynamic setters to trigger observer methods.
- * @note See `ManagedObject.addEventHandler` for another way to handle events emitted directly by instances of a managed object class.
+ * Static property decorator: add the decorated observer to _all instances_ of the target class and derived classes.
+ * @see `ManagedObject.addObserver`
  * @decorator
  */
 export function observe<C extends ManagedObjectConstructor>(

--- a/src/ui/UITheme.ts
+++ b/src/ui/UITheme.ts
@@ -267,7 +267,7 @@ export class UITheme {
       dimensions: { grow: 1, shrink: 1 },
     }),
     cell: UIStyle.create("_cell", {
-      containerLayout: { distribution: "space-around", gravity: "center" },
+      containerLayout: { distribution: "center", gravity: "center" },
       position: { top: 0 },
     }),
     cell_flow: UIStyle.create("_cell_flow", {

--- a/src/ui/containers/UICell.ts
+++ b/src/ui/containers/UICell.ts
@@ -1,3 +1,4 @@
+import { Binding } from "../../core";
 import {
   UIComponentEventHandler,
   UIRenderable,
@@ -6,7 +7,6 @@ import {
 import { UIStyle } from "../UIStyle";
 import { UITheme, UIColor } from "../UITheme";
 import { UIContainer } from "./UIContainer";
-import { Binding } from "../../core";
 
 /** Basic animated transition types, used for `UICell.revealTransition` and `UICell.exitTransition`. More transitions may be available depending on platform and cell type. */
 export enum UICellTransition {
@@ -32,19 +32,20 @@ export class UICell extends UIContainer {
     delete presets.decoration;
     let origDecoration: Readonly<UIStyle.Decoration> | undefined;
     if (Binding.isBinding(decoration)) {
-      (this as any).presetBinding("decoration", decoration, function (
-        this: UICell,
-        v: any
-      ) {
-        this.decoration = v ? { ...origDecoration!, ...v } : origDecoration;
-      });
+      (this as any).presetBinding(
+        "decoration",
+        decoration,
+        function (this: UICell, v: any) {
+          this.decoration = v ? { ...origDecoration!, ...v } : origDecoration;
+        }
+      );
       decoration = undefined;
     }
 
     if (presets.allowKeyboardFocus) presets.allowFocus = presets.allowKeyboardFocus;
     if (presets.selectOnFocus) {
       presets.allowFocus = true;
-      presets.onFocusIn = "+Select";
+      presets.onFocusIn = "Select";
       delete presets.selectOnFocus;
     }
     let f = super.preset(presets, ...rest);
@@ -151,7 +152,7 @@ export namespace UICell {
     /** Opacity (0-1) */
     opacity?: number;
 
-    /** Set to true to select cells on focus (or click), implies allowFocus as well */
+    /** Set to true to select cells on focus, implies allowFocus as well */
     selectOnFocus?: boolean;
     /** Set to true to allow this cell *itself* to receive input focus using mouse, touch, or `UIComponent.requestFocus` */
     allowFocus?: boolean;

--- a/src/ui/containers/UIContainer.ts
+++ b/src/ui/containers/UIContainer.ts
@@ -1,4 +1,11 @@
-import { Binding, Component, ComponentEvent, managedChild, ManagedList } from "../../core";
+import {
+  Binding,
+  Component,
+  ComponentEvent,
+  delegateEvents,
+  managedChild,
+  ManagedList,
+} from "../../core";
 import { UIComponent, UIRenderable, UIRenderableConstructor } from "../UIComponent";
 import { UIStyle } from "../UIStyle";
 
@@ -68,6 +75,7 @@ export abstract class UIContainer extends UIComponent {
   animatedContentRenderingVelocity?: number;
 
   /** Content components list */
+  @delegateEvents
   @managedChild
   readonly content: ManagedList<UIRenderable>;
 }

--- a/src/ui/containers/UIForm.ts
+++ b/src/ui/containers/UIForm.ts
@@ -16,14 +16,11 @@ export class UIForm extends UIRenderableController {
     presets: UIForm.Presets,
     ...rest: Array<UIRenderableConstructor | undefined>
   ) {
-    let formContextPreset = presets.formContext;
+    let formContextPreset = presets.formContext || bind("formContext");
     delete presets.formContext;
     let CellClass = _FormCell.with(presets, ...rest);
     this.presetBoundComponent("content", CellClass).limitBindings("formContext");
-    return super.preset(
-      { formContext: formContextPreset || bind("formContext") },
-      CellClass
-    );
+    return super.preset({ formContext: formContextPreset }, CellClass);
   }
 
   /** Form state context; should be bound to a `UIFormContext` component */
@@ -34,7 +31,7 @@ export class UIForm extends UIRenderableController {
 export namespace UIForm {
   /** UIForm presets type, for use with `Component.with` */
   export interface Presets extends UICell.Presets {
-    /** Form state context; should be bound to a `UIFormContext` component */
+    /** Form state context; should be bound to a `UIFormContext` component. If not set, automatically binds to a 'formContext' property on the bound parent component */
     formContext?: ManagedRecord;
     /** Event handler for form submissions */
     onSubmit: ComponentEventHandler<UIForm>;

--- a/src/ui/controllers/UIListCellAdapter.ts
+++ b/src/ui/controllers/UIListCellAdapter.ts
@@ -9,7 +9,7 @@ import {
   observe,
 } from "../../core";
 import { UICell } from "../containers/UICell";
-import { UIRenderableConstructor } from "../UIComponent";
+import { UIComponentEvent, UIRenderableConstructor } from "../UIComponent";
 import { UIRenderableController } from "../UIRenderableController";
 
 /** Action event that is emitted on a particular `UIListCellAdapter`. */
@@ -95,9 +95,12 @@ export class UIListCellAdapter<
     this.emit(event.freeze());
   }
 
-  /** Override event delegation, to delegate events of type `UIListCellAdapterEvent` instead of `ActionEvent`, if not already wrapped; other events are handled as normal */
+  /** Override event delegation, to delegate events of type `UIListCellAdapterEvent`, if not already wrapped */
   protected delegateEvent(e: ManagedEvent, propertyName: string) {
-    if (e instanceof ActionEvent && !(e instanceof UIListCellAdapterEvent)) {
+    if (
+      (e instanceof ActionEvent && !(e instanceof UIListCellAdapterEvent)) ||
+      e instanceof UIComponentEvent
+    ) {
       e = new UIListCellAdapterEvent(e.name, this, e);
     }
     return super.delegateEvent(e, propertyName);

--- a/src/ui/controllers/UIListCellAdapter.ts
+++ b/src/ui/controllers/UIListCellAdapter.ts
@@ -1,4 +1,5 @@
 import {
+  ActionEvent,
   ComponentEvent,
   ComponentEventHandler,
   managed,
@@ -11,13 +12,16 @@ import { UICell } from "../containers/UICell";
 import { UIRenderableConstructor } from "../UIComponent";
 import { UIRenderableController } from "../UIRenderableController";
 
-/** Event that is emitted on a particular `UIListCellAdapter`. */
+/** Action event that is emitted on a particular `UIListCellAdapter`. */
 export class UIListCellAdapterEvent<
   TObject extends ManagedObject = ManagedObject
-> extends ComponentEvent {
+> extends ActionEvent {
   constructor(name: string, source: UIListCellAdapter<TObject>, inner?: ManagedEvent) {
     super(name, source, inner);
     if (!source.content) throw TypeError();
+    this.context = source.object;
+
+    // set UIListCellAdapter specific properties
     this.object = source.object;
     this.cell = source.content;
     this.value = source.value;
@@ -33,7 +37,11 @@ export class UIListCellAdapterEvent<
   readonly value?: any;
 }
 
-/** Component that can be used as an adapter to render items in a `UIListController`. Instances are constructed using a single argument (a managed object from `UIListController.items`), and encapsulate a `UICell` component. The static `with` method takes the same arguments as `UICell` itself along with additional properties to manage display of selected and focused cells. Encapsulated content can include bindings to the `object`, `value`, `selected`, and `hovered` properties. */
+/**
+ * Component that can be used as an adapter to render items in a `UIListController`. Instances are constructed using a single argument (a managed object from `UIListController.items`), and encapsulate a `UICell` component.
+ * Encapsulated content can include bindings to the `object`, `value`, `selected`, and `hovered` properties.
+ * Events of type `ActionEvent` are wrapped in an event of type `UIListCellAdapterEvent`, which contains references to the cell and current list item object or value. Events that are already of type `UIListCellAdapterEvent` are not wrapped a second time, i.e. event properties are specific to the innermost adapter.
+ */
 export class UIListCellAdapter<
   TObject extends ManagedObject = ManagedObject
 > extends UIRenderableController<UICell> {
@@ -64,13 +72,6 @@ export class UIListCellAdapter<
     super();
     this.object = object;
     this.value = object.valueOf();
-
-    // propagate events as `UIListCellAdapterEvent`
-    this.propagateChildEvents(e => {
-      if (e instanceof ComponentEvent) {
-        return new UIListCellAdapterEvent(e.name, this, e);
-      }
-    });
   }
 
   /** The encapsulated object */
@@ -80,19 +81,35 @@ export class UIListCellAdapter<
   /** The intrinsic value of the encapsulated object (result of `valueOf()` called on the original object) */
   readonly value: any;
 
-  /** Create and emit a `UIListCellAdapterEvent` with given name and a reference to this component and its cell and object; see `Component.propagateComponentEvent` */
+  /** Create and emit a `UIListCellAdapterEvent` with given name and a reference to this component and its cell and object
+   * @deprecated in v3.1 */
   propagateComponentEvent(name: string, inner?: ManagedEvent) {
     if (!this.managedState) return;
     this.emit(UIListCellAdapterEvent, name, this, inner);
   }
 
-  /** True if the cell is currently selected (based on `Select` and `Deselect` events) */
+  /** Emit an an action event (overridden from `Component.emitAction`, to emit `UIListCellAdapterEvent` instead) */
+  emitAction(name: string, inner?: ManagedEvent, context?: ManagedObject) {
+    let event = new UIListCellAdapterEvent(name, this, inner);
+    event.context = context;
+    this.emit(event.freeze());
+  }
+
+  /** Override event delegation, to delegate events of type `UIListCellAdapterEvent` instead of `ActionEvent`, if not already wrapped; other events are handled as normal */
+  protected delegateEvent(e: ManagedEvent, propertyName: string) {
+    if (e instanceof ActionEvent && !(e instanceof UIListCellAdapterEvent)) {
+      e = new UIListCellAdapterEvent(e.name, this, e);
+    }
+    return super.delegateEvent(e, propertyName);
+  }
+
+  /** True if the cell is currently selected (based on `Select` and `Deselect` events; read-only) */
   @shadowObservable("_selected")
   get selected() {
     return this._selected;
   }
 
-  /** True if the cell is currently hovered over using the mouse cursor (based on `MouseEnter` and `MouseLeave` events) */
+  /** True if the cell is currently hovered over using the mouse cursor (based on `MouseEnter` and `MouseLeave` events; read-only) */
   @shadowObservable("_hovered")
   get hovered() {
     return this._hovered;

--- a/src/ui/controllers/UIModalController.ts
+++ b/src/ui/controllers/UIModalController.ts
@@ -1,5 +1,5 @@
 import { Application } from "../../app";
-import { Binding, ComponentConstructor, ComponentEvent, managedChild } from "../../core";
+import { Binding, ComponentConstructor, delegateEvents, managedChild } from "../../core";
 import { err, ERROR } from "../../errors";
 import { UIComponent, UIRenderable, UIRenderableConstructor } from "../UIComponent";
 import { UIRenderableController } from "../UIRenderableController";
@@ -27,20 +27,16 @@ export class UIModalController extends UIRenderableController {
     return super.preset(presets, Content);
   }
 
-  constructor() {
-    super();
-    this.propagateChildEvents(e => {
-      if (e instanceof ComponentEvent) {
-        if (e.name === "ShowModal") {
-          this.showModal();
-          return;
-        } else if (e.name === "CloseModal") {
-          this.closeModal();
-          return;
-        }
-        return e;
-      }
-    });
+  /** Handle 'ShowModal' events delegated from content components, by creating the modal component */
+  onShowModal() {
+    this.showModal();
+    return true;
+  }
+
+  /** Handle 'CloseModal' events delegated from content or modal components, by removing the modal component */
+  onCloseModal() {
+    this.closeModal();
+    return true;
   }
 
   /** Show the (preset) modal component */
@@ -54,6 +50,7 @@ export class UIModalController extends UIRenderableController {
   }
 
   /** The current modal component to be displayed, as a managed child reference, or undefined if the modal component is currently not displayed */
+  @delegateEvents
   @managedChild
   modal?: UIRenderable;
 

--- a/src/ui/controllers/UISelectionController.ts
+++ b/src/ui/controllers/UISelectionController.ts
@@ -1,32 +1,30 @@
 import { Component, ComponentEvent, managed } from "../../core";
-import { UIRenderable } from "../UIComponent";
 import { UIRenderableController } from "../UIRenderableController";
 
 /** Renderable wrapper that controls selection state across components, by emitting `Deselect` events for previously selected components upon `Select` events on newly selected components */
 export class UISelectionController extends UIRenderableController {
-  /** Create a new selection controller with given content */
-  constructor(content?: UIRenderable) {
-    super(content);
-    this.propagateChildEvents(e => {
-      // propagate all UI events, while managing selection state
-      if (e instanceof ComponentEvent) {
-        let ce = e;
-        while (ce.inner instanceof ComponentEvent && ce.inner.name === "Select") {
-          ce = ce.inner;
-        }
-        if (ce.name === "Select" && ce.source !== this.selected) {
-          let old = this.selected;
-          this.selected = ce.source;
-          if (old) old.propagateComponentEvent("Deselect");
-        } else if (ce.name === "Deselect" && ce.source === this.selected) {
-          this.selected = undefined;
-        }
-        return e;
-      }
-    });
-  }
-
   /** Currently selected component, if any */
   @managed
   selected?: Component;
+
+  /** Handle Select events, remember the (original) source component and deselect the previously selected component, if any */
+  onSelect(e: ComponentEvent) {
+    if (e.source === this.selected) return;
+    while (e.inner instanceof ComponentEvent && e.inner.name === "Select") {
+      e = e.inner;
+      if (e.source === this.selected) return;
+    }
+    let old = this.selected;
+    this.selected = e.source;
+    if (old && old.managedState) old.emitAction("Deselect");
+  }
+
+  /** Handle Deselect events (only if their source is the currently selected component) */
+  onDeselect(e: ComponentEvent) {
+    if (e.source === this.selected) this.selected = undefined;
+    while (e.inner instanceof ComponentEvent && e.inner.name === "Deselect") {
+      e = e.inner;
+      if (e.source === this.selected) this.selected = undefined;
+    }
+  }
 }

--- a/test/TestCase.ts
+++ b/test/TestCase.ts
@@ -21,7 +21,7 @@ export class TestCase {
         if (this._failTimer) {
           clearTimeout(this._failTimer);
         }
-        resolve();
+        resolve(undefined);
       };
     });
   }
@@ -43,7 +43,7 @@ export class TestCase {
   fail(err?: any): void;
   fail(err?: any) {
     if (typeof err === "string") {
-      err = Error(this._testNameToString("Failure"));
+      err = Error(this._testNameToString(err));
     }
     this._error = err || new Error(this._testNameToString("Failure"));
     this._resolve();
@@ -125,7 +125,7 @@ export class TestCase {
     );
   }
 
-  private async _goAsync(callback?: (t: this) => void) {
+  private async _goAsync(callback?: (t: this) => void | Promise<void>) {
     try {
       if (callback) await callback(this);
       else this._resolve();

--- a/test/cases/01 core/05 Component.ts
+++ b/test/cases/01 core/05 Component.ts
@@ -4,6 +4,8 @@ import {
   bind,
   ComponentConstructor,
   ManagedList,
+  managed,
+  delegateEvents,
 } from "../../../dist";
 
 consider("Component", () => {
@@ -163,5 +165,49 @@ consider("Component", () => {
         t.test(c.seeThrough.child.a === 2 && c.seeThrough.child.s === "OK");
       });
     });
+  });
+
+  it("can delegate events", t => {
+    class B extends Component {}
+    class A extends Component {
+      @managed
+      @delegateEvents
+      b = new B();
+      onOK() {
+        t.ok();
+      }
+    }
+    new A().b.emit("OK");
+  });
+
+  it("can delegate events (reverse)", t => {
+    class B extends Component {}
+    class A extends Component {
+      @delegateEvents
+      @managed
+      b = new B();
+      onOK() {
+        t.ok();
+      }
+    }
+    new A().b.emit("OK");
+  });
+
+  it("propagates action events", t => {
+    class C extends Component {}
+    class B extends Component {
+      @managed
+      @delegateEvents
+      c = new C();
+    }
+    class A extends Component {
+      @managed
+      @delegateEvents
+      b = new B();
+      onOK() {
+        t.ok();
+      }
+    }
+    new A().b.c.emitAction("OK");
   });
 });


### PR DESCRIPTION
This PR includes the bulk of changes for v3.1, inspired by challenges in completing the Typescene docs and explaining how components work in simple terms.

There are two key changes in this PR:

1. Deprecate (by no longer mentioning... although the functionality has not been removed) the use of `{ "onClick": "callSomeMethod()" }` in component presets. This is a 'shortcut' that seems useful, but introduces the possibility for errors, while not being type safe either (i.e. arguments are not checked, the method may not be intended to be used as an event handler).
2. Deprecate (using the `@deprecated` JSDoc tag) the use of `propagateChildEvents` and `propagateComponentEvent`. These are confusingly named, and hard to understand as well. The concept of propagation (of events to parent components) is still around, but now, components use a more traditional way of handling events from referenced (not just child) components instead, with:
    - A new `@delegateEvents` decorator on managed reference properties, which causes events from referenced objects to be 'handled' by the referencing component
    - A new method `delegateEvent(e)`, which is called for each event that needs to be handled
    - A base implementation in `Component`, that calls handler methods by name (e.g. `onButtonClick(e)`) on the referencing component. If a handler doesn't exist, or doesn't return `true` -- in other words, if the event is not actually handled by the component itself, _and_ if the event is of type `ActionEvent` (new) then the event is propagated (i.e. emitted) on the component itself.
    - The `delegateEvent(e)` method can be overridden to handle events directly within that method, or to call other methods, or to propagate other types of events (instead of just ActionEvent -- this is used by e.g. UIComponent to propagate UI events as well)

These changes make it more obvious that
- bindings are used to push state from a component _down_ to its sub components, e.g. in the view (this is still the same)
- events are emitted and handled _upwards_ to referencing (parent) components, e.g. view events which are handled by parent views and/or activities.

The answer to 'how do I handle events' is now simply A) to write a handler method with a specific name (e.g. `onAddTask(e)` to handle an `AddTask` event) on the parent component, or in some cases B) to override the `delegateEvent(e)` method itself. If both of these won't work, then perhaps an observer would do the trick, but that's now a more advanced scenario.
