### PR TITLE
Activate app activities if none have paths

### DIFF
--- a/src/app/AppActivityList.ts
+++ b/src/app/AppActivityList.ts
@@ -74,6 +74,26 @@ export class AppActivityList extends Component {
     return this.$list.includes(activity);
   }
 
+  /**
+   * Iterates over the activities in this list and invokes given callback for each activity
+   * @param callback
+   *  the function to be called, with a single activity as the only argument
+   * @see `ManagedList.forEach()`
+   */
+  forEach(callback: (target: AppActivity) => void) {
+    this.$list.forEach(callback);
+  }
+
+  /**
+   * Iterates over the activities in this list and invokes given callback for each activity, then returns an array with all callback return values.
+   * @param callback
+   *  the function to be called, with a single activity as the only argument
+   * @note The behavior of this method is undefined if the activity list is changed while running.
+   */
+  map<TResult>(callback: (target: AppActivity) => TResult): TResult[] {
+    return this.$list.map(callback);
+  }
+
   /** Returns an array with all activities currently in this list */
   toArray() {
     return this.$list.toArray();

--- a/src/app/Application.ts
+++ b/src/app/Application.ts
@@ -20,7 +20,7 @@ import { AppActivityList } from "./AppActivityList";
  */
 export class Application extends Component {
   /**
-   * Create an application that includes given activities, and start it immediately.
+   * Create an application that includes given activities, and start it immediately. If none of the activities has a `path` property, then all activities are activated immediately; otherwise each activity will activate itself using the current `activationContect`.
    * @returns the application instance
    * @note Calling this method directly on `Application` creates an application without any context (i.e. `activationContext` and `renderContext`). Instead, use a constructor that is meant for a specific platform (e.g. `BrowserApplication`).
    */
@@ -59,8 +59,20 @@ export class Application extends Component {
       this.presetBoundComponent("activities", L, AppActivity);
       this.addEventHandler(function (e) {
         // toggle property based on activation state
-        if (e === ManagedCoreEvent.ACTIVE) this.activities = new L();
-        if (e === ManagedCoreEvent.INACTIVE) this.activities = undefined;
+        if (e === ManagedCoreEvent.INACTIVE) {
+          this.activities = undefined;
+        }
+        if (e === ManagedCoreEvent.ACTIVE) {
+          this.activities = new L();
+
+          // if none of the activities has a path, activate all of them now
+          let paths = this.activities.map(a => a.path).filter(s => !!s);
+          if (!paths.length) {
+            this.activities.forEach(a => {
+              a.activateAsync().catch(logUnhandledException);
+            });
+          }
+        }
       });
     }
     return super.preset(presets);


### PR DESCRIPTION
Quick change that makes it easier to write apps with a single activity, or multiple activities that do not use URL activation.

If none of the activities passed to `Application.with(...)` or `.run(...)` have a `path` property set, then all given activities are activated as soon as the Application itself is activated.