### PR TITLE
Cleanup and features for v3.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 dist/
+dist-*/
 node_modules/
 *.log
 npm-debug.log*

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "index.d.ts"
   ],
   "scripts": {
-    "clean": "rimraf dist",
+    "clean": "rimraf dist dist-es6 dist-es8",
     "prepublishOnly": "npm run build",
     "prebuild": "npm run clean && tsc -p src --declaration",
     "build-es8": "tsc -p src --target es2017 --outDir dist-es8 --removeComments",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
   "typings": "./index.d.ts",
   "files": [
     "dist",
+    "dist-es6",
+    "dist-es8",
     "index.js",
     "index.d.ts"
   ],
@@ -28,9 +30,11 @@
     "clean": "rimraf dist",
     "prepublishOnly": "npm run build",
     "prebuild": "npm run clean && tsc -p src --declaration",
-    "build": "tsc -p src --removeComments",
+    "build-es8": "tsc -p src --target es2017 --outDir dist-es8 --removeComments",
+    "build-es6": "tsc -p src --target es2015 --outDir dist-es6 --removeComments",
+    "build-es5": "tsc -p src --removeComments",
+    "build": "npm run build-es5 && npm run build-es6 && npm run build-es8",
     "postbuild": "node test/run",
-    "watch": "tsc -p src -w",
     "test": "node test/run"
   },
   "dependencies": {

--- a/src/app/AppComponent.ts
+++ b/src/app/AppComponent.ts
@@ -1,5 +1,5 @@
 import { bind, Component, managed } from "../core";
-import { renderContextBinding, UIRenderContext } from "../ui";
+import { renderContextBinding, UIRenderContext, viewportContextBinding } from "../ui";
 import { AppActivationContext } from "./AppActivationContext";
 
 /** @internal Activation context binding, can be reused to avoid creating new bindings */
@@ -8,11 +8,16 @@ export const activationContextBinding = bind("activationContext");
 /** Specialized `Component` that propagates application properties (abstract) */
 export abstract class AppComponent extends Component.with({
   renderContext: renderContextBinding,
+  viewportContext: viewportContextBinding,
   activationContext: activationContextBinding,
 }) {
   /** Application render context, propagated from the parent composite object */
   @managed
   renderContext?: UIRenderContext;
+
+  /** Observable viewport context data, propagated from the parent composite object */
+  @managed
+  viewportContext?: any;
 
   /** Activation context, propagated from the parent composite object */
   @managed

--- a/src/app/Application.ts
+++ b/src/app/Application.ts
@@ -13,6 +13,9 @@ import { AppActivationContext } from "./AppActivationContext";
 import { AppActivity } from "./AppActivity";
 import { AppActivityList } from "./AppActivityList";
 
+/** Handler that is used for automatic class updates (e.g. hot module reload) */
+let _autoUpdateHandler: undefined | Function;
+
 /**
  * Represents the application itself, encapsulates activities (`AppActivity` components) and contexts for rendering and activation using URL-like paths.
  * Use the static `run` method to create and activate an application using a set of activity constructors, or create an application class that includes activities as (preset) bound components.
@@ -76,6 +79,24 @@ export class Application extends Component {
       });
     }
     return super.preset(presets);
+  }
+
+  /** Set a handler that is used to register classes and modules for automatic update/reload; this method is used by e.g. `@typescene/webapp` to support Hot Module Reload */
+  static setAutoUpdateHandler<T extends ComponentConstructor>(
+    f: (module: any, C: T, methodName: string & keyof T) => void
+  ) {
+    _autoUpdateHandler = f;
+  }
+
+  /** Register given class and module for automatic update/reload; this method is used by e.g. `ViewActivity` and should not be used on its own */
+  static registerAutoUpdate<T extends ComponentConstructor>(
+    module: any,
+    C: T,
+    methodName: string & keyof T
+  ) {
+    setTimeout(() => {
+      if (_autoUpdateHandler) _autoUpdateHandler(module, C, methodName as string);
+    }, 10);
   }
 
   /** The application name */

--- a/src/ui/UIRenderContext.ts
+++ b/src/ui/UIRenderContext.ts
@@ -5,6 +5,9 @@ import { UIComponent, UIRenderable } from "./UIComponent";
 /** @internal Render context binding, can be reused to avoid creating new bindings */
 export const renderContextBinding = bind("renderContext");
 
+/** @internal Viewport context binding, can be reused */
+export const viewportContextBinding = bind("renderContext.viewportContext");
+
 /** Global view placement modes */
 export enum UIRenderPlacement {
   NONE,
@@ -21,6 +24,9 @@ export enum UIRenderPlacement {
 
 /** Base application render context, to be extended with platform specific render implementation. */
 export abstract class UIRenderContext extends ManagedObject {
+  /** Observable viewport data; propagated to `AppActivity` and `ViewComponent` so that it can be used by bindings within view components */
+  abstract viewportContext: any;
+
   /** Emit a change event for this context, e.g. when the viewport orientation or current locale changes. This will trigger all views to re-render if needed. */
   emitRenderChange() {
     this.emitChange();

--- a/src/ui/UITheme.ts
+++ b/src/ui/UITheme.ts
@@ -53,9 +53,37 @@ export abstract class UIMenuBuilder {
 
 /** Represents a single color (read-only) */
 export class UIColor {
+  static readonly Black = new UIColor("black");
+  static readonly DarkerGray = new UIColor("darkerGray");
+  static readonly DarkGray = new UIColor("darkGray");
+  static readonly Gray = new UIColor("gray");
+  static readonly LightGray = new UIColor("lightGray");
+  static readonly White = new UIColor("white");
+  static readonly Slate = new UIColor("slate");
+  static readonly Red = new UIColor("red");
+  static readonly Orange = new UIColor("orange");
+  static readonly Yellow = new UIColor("yellow");
+  static readonly Lime = new UIColor("lime");
+  static readonly Green = new UIColor("green");
+  static readonly Turquoise = new UIColor("turquoise");
+  static readonly Cyan = new UIColor("cyan");
+  static readonly Blue = new UIColor("blue");
+  static readonly Violet = new UIColor("violet");
+  static readonly Purple = new UIColor("purple");
+  static readonly Magenta = new UIColor("magenta");
+  static readonly Primary = new UIColor("primary");
+  static readonly Accent = new UIColor("accent");
+  static readonly Background = new UIColor("background");
+  static readonly Text = new UIColor("text");
+
   constructor(colorName?: string) {
     if (colorName) {
-      this._f = () => (UITheme.current && UITheme.current.colors[colorName]) || colorName;
+      this._f = () => {
+        let color = String(
+          (UITheme.current && UITheme.current.colors[colorName]) || colorName
+        );
+        return color[0] === "@" ? UITheme.replaceColor(color) : color;
+      };
     }
   }
 
@@ -183,9 +211,8 @@ export class UITheme {
    * - `@green.text` is substituted with a contrasting text color (mostly-opaque white or black) that is readable on the color `green`.
    */
   static replaceColor(color: UIColor | string) {
-    if (color instanceof UIColor) return String(color);
     let c = String(color);
-    if (!c) return c;
+    if (!c || color instanceof UIColor) return c;
     // (Note: .text also works as :text for historical reasons)
     return c.replace(
       /\@(\w+)([.:]text)?((\^)?[\+\-]\d+\%)?([.:]text)?(\/\d+\%)?([.:]text)?/g,
@@ -235,15 +262,28 @@ export class UITheme {
 
   /** Set of predefined colors */
   colors: { [name: string]: string } = {
-    red: "#f00",
-    green: "#0f0",
-    blue: "#00f",
-    black: "#000",
-    white: "#fff",
+    black: "#000000",
+    darkerGray: "#333333",
+    darkGray: "#777777",
+    gray: "#aaaaaa",
+    lightGray: "#dddddd",
+    white: "#ffffff",
+    slate: "#667788",
+    red: "#ff0000",
+    orange: "#ee9933",
+    yellow: "#ffff00",
+    lime: "#77ff00",
+    green: "#007700",
+    turquoise: "#33aa99",
+    cyan: "#00ffff",
+    blue: "#0000ff",
+    violet: "#ee77cc",
+    purple: "#aa3399",
+    magenta: "#ff00ff",
     primary: "@blue",
-    accent: "@red",
+    accent: "@purple",
     background: "@white",
-    text: "@background:text",
+    text: "@background.text",
     separator: "@background^-50%/20%",
     modalShade: "@black",
   };
@@ -286,11 +326,11 @@ export class UITheme {
       dimensions: { grow: 0 },
     }),
     column: UIStyle.create("_column", {
-      containerLayout: { axis: "vertical" },
+      containerLayout: { axis: "vertical", gravity: "start" },
       dimensions: { grow: 0, shrink: 0 },
     }),
     row: UIStyle.create("_row", {
-      containerLayout: { axis: "horizontal" },
+      containerLayout: { axis: "horizontal", gravity: "center" },
       dimensions: { grow: 0, shrink: 0 },
     }),
     row_opposite: UIStyle.create("_row_opposite", {
@@ -300,7 +340,6 @@ export class UITheme {
       containerLayout: { distribution: "center" },
     }),
     control: UIStyle.create("_control", {
-      position: { gravity: "baseline" },
       dimensions: { shrink: 1, grow: 0 },
     }),
   };


### PR DESCRIPTION
Gathering changes here for pushing to v3.1 release.

- Build targets for ES6 and ES8 as separate folders, so that they can be used with e.g. Webpack, or a specific `.min.js` file when targeting modern browsers. These include native classes, and native async/await, respectively.
- Binding improvements, for and/or methods and also new then/else methods; I found these useful to bind styles directly, rather than having to rely on `UIStyleController` (which also has a fix in this release)
- Theme/style improvements
- A new 'viewport context' that is bound from the rendering context, to support responsive/adaptive design scenarios just using bindings (e.g. `bind("viewportContext.narrow")`)
- A new 'book end' component that can be added as the last parameter to `UIListController`, which can either function as an empty state _within_ the list element (if hidden when not required), and/or for rendering a bottom separator underneath the last item, and/or for pushing content in a container to the left/right using a spacer.