### PR TITLE
Fix: add inner event to action event

### DIFF
--- a/src/core/Component.ts
+++ b/src/core/Component.ts
@@ -195,7 +195,7 @@ export class Component extends ManagedObject {
     if (eventActions) {
       this.addEventHandler(function (e) {
         let actionName = eventActions![e.name];
-        if (actionName) this.emitAction(actionName);
+        if (actionName) this.emitAction(actionName, e);
       });
     }
     if (eventHandlers) {


### PR DESCRIPTION
Forgot to add `inner` property to new action events from the event handler that is created for preset components.