### PR TITLE
Rename bind()/strf() filter `or` to `else`

### DIFF
--- a/src/core/I18nService.ts
+++ b/src/core/I18nService.ts
@@ -149,7 +149,7 @@ export class I18nString {
  * - `%{?}` for true or false (boolean) and `%{!}` for negation
  * - `%{n}` or `%{num}` for values cast to Number
  * - `%{then:a:b}` to select strings a or b based on boolean value
- * - `%{or:b}` to select string b if the value is not boolean true
+ * - `%{else:b}` to select string b if the value is not boolean true
  * - `%{local:...}` for I18n-formatted values; the type part(s) are variable, and will need to be implemented by the `I18nService.format` method of the currently registered I18n service, e.g. `strf("%{local:date}", new Date())`.
  * @note Asterisks (`*`) anywhere in a placeholder are replaced by the next value in the parameter list (_before_ the value being represented itself), e.g. in `strf("%.*f", precision, number)` and `strf("%{local:currency:*}", currency, number)`.
  * @note Floating point numbers are formatted using the decimal separator specified by the `I18nService.decimalSeparator` property of the currently registered I18n service, if any. Number grouping separators are not supported, and if necessary numbers will need to be formatted using %{local:...}.

--- a/src/core/format.ts
+++ b/src/core/format.ts
@@ -186,8 +186,9 @@ const _filters: { [id: string]: (v: any, ...args: any[]) => any } = {
   "!!": v => !!v,
   "n": v => +v,
   "num": v => +v,
-  "or": (v, alt) => v || alt,
   "then": (v, a, b) => (v && a) || b,
+  "else": (v, alt) => v || alt,
+  "or": (v, alt) => v || alt, // DEPRECATED! confusing, not same as bind().or(...)
   "uc": _ucFilter,
   "lc": _lcFilter,
   "uniq": _uniqueFilter,


### PR DESCRIPTION
The 'or' filter was confusing, because it doesn't do the same as bind(...).or(...) which expects another **binding**, not a plain value. It's in fact the same as bind(...).else(...), so renaming this 'else' as well.

Leaving 'or' in the code as well for backwards compatibility but this is quasi-deprecated now since it's no longer mentioned in the docs.