### PR TITLE
Add component decorator

### DIFF
--- a/src/app/AppActivity.ts
+++ b/src/app/AppActivity.ts
@@ -1,13 +1,16 @@
-import { ManagedState, shadowObservable, observe } from "../core";
-import { AppActivationContext } from "./AppActivationContext";
+import { ManagedState, shadowObservable, observe, ComponentConstructor } from "../core";
+import type { AppActivationContext } from "./AppActivationContext";
+import type { Application } from "./Application";
 import { AppComponent } from "./AppComponent";
-import { Application } from "./Application";
 
 /** Activity base class. Represents a component of an application, which can be activated and deactivated independently. Can be used for activities that are activated independently of the UI; otherwise refer to any of the `ViewActivity` classes. Activities are usually preset on the `Application` constructor instead of being constructed independently, except when necessary to facilitate 'lazy' loading of parts of the application code. */
 export class AppActivity extends AppComponent {
   static preset(presets: AppActivity.Presets): Function {
     return super.preset(presets);
   }
+
+  /** @internal Application reference (avoid importing Application to break circular dependency) */
+  static Application: ComponentConstructor;
 
   /** Create a new activity with given name and activation path, both optional. */
   constructor(name?: string, path?: string) {
@@ -35,7 +38,7 @@ export class AppActivity extends AppComponent {
 
   /** Returns the parent application that contains this activity, if any */
   getApplication() {
-    return this.getManagedParent(Application);
+    return this.getManagedParent(AppActivity.Application) as Application | undefined;
   }
 
   /** Activate this activity, optionally based on given captured path segments (returned by `AppActivationContext.match`, for a path such as `foo/bar/:id`, `foo/*name`, or `./:id`). This method is called automatically when the activity path matches the current target path, but may also be called directly. This method can be overridden to validate the captured path segments before activation. */

--- a/src/app/Application.ts
+++ b/src/app/Application.ts
@@ -8,8 +8,8 @@ import {
   ManagedCoreEvent,
   delegateEvents,
 } from "../core";
-import { UIRenderContext } from "../ui";
-import { AppActivationContext } from "./AppActivationContext";
+import type { UIRenderContext } from "../ui";
+import type { AppActivationContext } from "./AppActivationContext";
 import { AppActivity } from "./AppActivity";
 import { AppActivityList } from "./AppActivityList";
 
@@ -59,7 +59,7 @@ export class Application extends Component {
     if (activities.length) {
       // preset an AppActivityList with given activities
       let L = AppActivityList.with(...activities);
-      this.presetBoundComponent("activities", L, AppActivity);
+      this.presetBoundComponent("activities", L);
       this.addEventHandler(function (e) {
         // toggle property based on activation state
         if (e === ManagedCoreEvent.INACTIVE) {
@@ -175,6 +175,10 @@ export class Application extends Component {
     return ManagedService.find(name);
   }
 }
+
+// Make sure bindings are in place for `activities`, even if not preset
+Application.presetBoundComponent("activities", AppActivity);
+AppActivity.Application = Application;
 
 export namespace Application {
   /** Application presets type, for use with `Component.with` */

--- a/src/app/ViewComponent.ts
+++ b/src/app/ViewComponent.ts
@@ -7,6 +7,7 @@ import {
   ComponentConstructor,
   delegateEvents,
   ManagedEvent,
+  component,
 } from "../core";
 import {
   UIComponent,
@@ -140,7 +141,7 @@ export class ViewComponent extends AppComponent implements UIRenderable {
   /**
    * Create a child view of given type automatically for each instance of the view component. Bindings for given properties are bound to the ViewComponent instance, others are ignored so that their values will be taken from the containing bound parent instead of the ViewComponent itself.
    * @param propertyName
-   *  The property that will be set. This property must _already_ be a managed child property, decorated using `@managedChild` and optionally `@delegateEvents` for event handling.
+   *  The property that will be set. This property must _already_ be a managed child property, decorated using `@component` and optionally `@delegateEvents` for event handling.
    * @param View
    *  The (preset) constructor for the child view. This constructor will be used to create a child component for each `ViewComponent` instance.
    * @param boundProperties
@@ -173,7 +174,7 @@ export class ViewComponent extends AppComponent implements UIRenderable {
 
   /** The root component that makes up the content for this view, as a managed child reference */
   @delegateEvents
-  @managedChild
+  @component
   view?: UIRenderable;
 
   /** Override event delegation, to _also_ propagate events of type `UIComponentEvent` */

--- a/src/core/Binding.ts
+++ b/src/core/Binding.ts
@@ -1,5 +1,5 @@
 import { err, ERROR } from "../errors";
-import { Component } from "./Component";
+import type { Component } from "./Component";
 import { ManagedList } from "./ManagedList";
 import { logUnhandledException } from "./UnhandledErrorEmitter";
 import { HIDDEN } from "./util";

--- a/src/core/ManagedEvent.ts
+++ b/src/core/ManagedEvent.ts
@@ -47,7 +47,7 @@ export namespace ManagedCoreEvent {
   export const DESTROYED = new ManagedCoreEvent("Destroyed").freeze();
 }
 
-/** Event that is emitted when a reference to a managed object is assigned to a managed child reference property (i.e. a property decorated with the `@managedChild` decorator); the child object emits this event, with `parent` set to the _new_ parent object, and `propertyName` set to the property name (only if the child object is _directly_ assigned to a property of the parent object) */
+/** Event that is emitted when a reference to a managed object is assigned to a managed child reference property (i.e. a property decorated with the `@managedChild` or `@component` decorators); the child object emits this event, with `parent` set to the _new_ parent object, and `propertyName` set to the property name (only if the child object is _directly_ assigned to a property of the parent object) */
 export class ManagedParentChangeEvent extends ManagedCoreEvent {
   constructor(parent: ManagedObject, propertyName?: string) {
     super("ManagedParentChange");

--- a/src/core/ManagedObject.ts
+++ b/src/core/ManagedObject.ts
@@ -200,7 +200,7 @@ export class ManagedObject {
     return this[HIDDEN.REFCOUNT_PROPERTY];
   }
 
-  /** Returns an array of unique managed objects that contain managed references to this object (see `@managed` and `@managedChild` decorators) */
+  /** Returns an array of unique managed objects that contain managed references to this object (see `@managed`, `@managedChild`, and `@component` decorators) */
   protected getManagedReferrers() {
     let seen: boolean[] = Object.create(null);
     let result: ManagedObject[] = [];
@@ -214,7 +214,7 @@ export class ManagedObject {
   }
 
   /**
-   * Returns the managed object that contains a _managed child reference_ that points to this instance, if any (see `@managedChild`).
+   * Returns the managed object that contains a _managed child reference_ that points to this instance, if any (see `@managedChild` and `@component` decorators).
    * If a class argument is specified, parent references are recursed until a parent of given type is found.
    * The object itself is never returned, even if it contains a managed child reference that points to itself.
    * @note The reference to the managed parent (but not its events) can be observed (see `addObserver`) using an `onManagedParentChange` or `onManagedParentChangeAsync` method on the observer.
@@ -299,7 +299,7 @@ export class ManagedObject {
   }
 
   /**
-   * Propagate events from managed child objects that are _referenced_ as properties of this object (see `@managedChild` decorator) by emitting the same events on this object itself.
+   * Propagate events from managed child objects that are _referenced_ as properties of this object (see `@managedChild` and `@component` decorators) by emitting the same events on this object itself.
    * @deprecated in favor of `@delegateEvents` since version 3.1
    */
   protected propagateChildEvents(
@@ -337,7 +337,7 @@ export class ManagedObject {
 
   /**
    * Destroy this managed object (i.e. change state to `ManagedState.DESTROYING` and then to `ManagedState.DESTROYED`, clear all managed references from and to this object, and destroy all managed children); the `onManagedStateDestroyingAsync` method is called in the process
-   * @note Managed child objects are automatically destroyed when [1] their parent's reference (decorated with `@managedChild`) is cleared or otherwise changed, or [2] the child object is removed from a managed list or map that is itself a managed child, or [3] when the parent object itself is destroyed.
+   * @note Managed child objects are automatically destroyed when [1] their parent's reference (decorated with `@managedChild` or `@component`) is cleared or otherwise changed, or [2] the child object is removed from a managed list or map that is itself a managed child, or [3] when the parent object itself is destroyed.
    */
   protected async destroyManagedAsync() {
     let n = 3;
@@ -632,7 +632,8 @@ export class ManagedObject {
     object: T,
     propertyKey: keyof T,
     isChildReference?: boolean,
-    readonlyRef?: ManagedReference
+    readonlyRef?: ManagedReference,
+    ClassRestriction?: ManagedObjectConstructor<any>
   ) {
     if (!(object instanceof ManagedObject)) {
       throw err(ERROR.Object_PropNotManaged);
@@ -665,7 +666,7 @@ export class ManagedObject {
             // do not assign to read only reference (but used by getter initially)
             throw err(ERROR.Object_NotWritable);
           }
-          ManagedObject._validateReferenceAssignment(obj, target);
+          ManagedObject._validateReferenceAssignment(obj, target, ClassRestriction);
           let cur = obj[HIDDEN.REF_PROPERTY][propId];
           if (cur && target && cur.b === target && !readonlyRef) return;
 

--- a/src/core/ManagedRecord.ts
+++ b/src/core/ManagedRecord.ts
@@ -64,7 +64,7 @@ export class ManagedRecord extends Component {
     return result;
   }
 
-  /** Returns the parent record (or parent's parent, etc.). If a class reference is specified, finds the nearest parent of given type. See `@managedChild` decorator. */
+  /** Returns the parent record (or parent's parent, etc.). If a class reference is specified, finds the nearest parent of given type. See `@managedChild` and `@component` decorators. */
   getParentRecord<TParent extends ManagedRecord = ManagedRecord>(
     ParentClass?: ManagedRecordConstructor<TParent>
   ) {
@@ -94,7 +94,7 @@ export class ManagedRecord extends Component {
   }
 
   /**
-   * Returns an array of unique records that contain managed references to this object (see `@managed` and `@managedChild`). This includes records that refer directly to this object, as well as those that refer to managed list(s) or map(s) that contain this record.
+   * Returns an array of unique records that contain managed references to this object (see `@managed`, `@managedChild`, and `@component`). This includes records that refer directly to this object, as well as those that refer to managed list(s) or map(s) that contain this record.
    * @param FilterByClass
    *  If specified, results will only include instances of given class. Other referrers are _not_ inspected recursively.
    */

--- a/src/core/observe.ts
+++ b/src/core/observe.ts
@@ -87,7 +87,7 @@ export function onPropertyChange(...observedProperties: string[]): MethodDecorat
 }
 
 /**
- * Observer method decorator: amend decorated method to turn it into a handler for events on managed objects that are referred to by given managed reference property/ies (decorated with `@managed` or `@managedChild`).
+ * Observer method decorator: amend decorated method to turn it into a handler for events on managed objects that are referred to by given managed reference property/ies (decorated with `@managed`, `@managedChild`, or `@component`).
  * @note This decorator is intended for use on methods that are part of an observer class, see `ManagedObject.addObserver()`.
  * @decorator
  */

--- a/src/ui/UIMenu.ts
+++ b/src/ui/UIMenu.ts
@@ -1,4 +1,4 @@
-import { Component, ComponentEventHandler, delegateEvents, managedChild } from "../core";
+import { component, Component, ComponentEventHandler, delegateEvents } from "../core";
 import { err, ERROR } from "../errors";
 import { Stringable, UIComponent, UIComponentEvent, UIRenderable } from "./UIComponent";
 import { UIRenderContext } from "./UIRenderContext";
@@ -55,7 +55,7 @@ export class UIMenu extends Component implements UIRenderable {
 
   /** The last menu that was built, as a child object */
   @delegateEvents
-  @managedChild
+  @component
   menu?: UIRenderable;
 
   /** Menu gravity in relation to reference component (start/stretch/end) */

--- a/src/ui/UIRenderableController.ts
+++ b/src/ui/UIRenderableController.ts
@@ -1,4 +1,4 @@
-import { Component, delegateEvents, managed, managedChild, ManagedEvent } from "../core";
+import { component, Component, delegateEvents, managed, ManagedEvent } from "../core";
 import {
   UIComponent,
   UIComponentEvent,
@@ -34,7 +34,7 @@ export class UIRenderableController<TContent extends UIRenderable = UIRenderable
 
   /** Renderable content, as a managed child reference */
   @delegateEvents
-  @managedChild
+  @component
   content?: TContent;
 
   /** Override event delegation, to _also_ propagate events of type `UIComponentEvent` */

--- a/src/ui/controllers/UIModalController.ts
+++ b/src/ui/controllers/UIModalController.ts
@@ -1,4 +1,3 @@
-import { Application } from "../../app";
 import { Binding, ComponentConstructor, delegateEvents, managedChild } from "../../core";
 import { err, ERROR } from "../../errors";
 import { UIComponent, UIRenderable, UIRenderableConstructor } from "../UIComponent";
@@ -73,11 +72,10 @@ UIModalController.addObserver(
       if (this._renderCallback) {
         this._renderCallback = this._renderCallback(undefined);
       }
-      if (this.controller.modal) {
+      if (this.controller.modal && this.controller.renderContext) {
         let ref = this._getReferenceComponent();
-        let application = this.controller.getBoundParentComponent(Application);
-        if (ref && application && application.renderContext) {
-          this._renderCallback = application.renderContext.getRenderCallback() as any;
+        if (ref) {
+          this._renderCallback = this.controller.renderContext.getRenderCallback() as any;
           let callbackProxy: UIRenderContext.RenderCallback = (output, afterRender) => {
             if (!this._renderCallback) return callbackProxy;
             if (output && output.element) {


### PR DESCRIPTION
Add decorator that is the equivalent of both `managedChild` and `presetBoundComponent`, to make it easier to add child components to Component classes, without having to use a preset function.

See tests for examples.