### PR TITLE
Improve navigation using events and modes

### DIFF
--- a/src/app/AppActivationContext.ts
+++ b/src/app/AppActivationContext.ts
@@ -2,6 +2,15 @@ import { ManagedObject } from "../core";
 import { err, ERROR } from "../errors";
 import { AppActivity } from "./AppActivity";
 
+/** Navigation mode(s) supported by `Application.navigate()` (and `AppActivationContext.navigate()`) */
+export interface ApplicationNavigationMode {
+  /** Set to true to navigate back in history *before* navigating to a specified path */
+  back?: boolean;
+
+  /** Set to true to *replace* the current navigation path with another path; afterwards, going back in history will not result in the current navigation path, but the one before it */
+  replace?: boolean;
+}
+
 /** Represents the application state using a single 'target' path in URL format. Used by `AppActivity` classes to implement routing behavior. This class is overridden by specialized implementations to work with platform features, e.g. DOM navigation in a Web browser. */
 export class AppActivationContext extends ManagedObject {
   /** The current full target path, in URL format without leading or trailing slashes (e.g. `foo/bar/123`), defaults to the empty string. Changes to this property automatically result in a change event being emitted on the activation context instance itself. */
@@ -20,7 +29,7 @@ export class AppActivationContext extends ManagedObject {
   private _split: string[] = [];
 
   /** Navigate to given (relative) path, in URL format or `:back` to go back in history; to be overridden, the base implementation does nothing. */
-  navigate(_path: string) {
+  navigate(_path: string, _mode?: ApplicationNavigationMode) {
     // to be overridden
   }
 

--- a/src/app/AppActivity.ts
+++ b/src/app/AppActivity.ts
@@ -121,6 +121,7 @@ export class AppActivity extends AppComponent {
     if (this.isActive()) {
       let path = String(e.source.getNavigationTarget?.() || "");
       if (path) this.getApplication()?.navigate(path);
+      return true;
     }
   }
 

--- a/src/app/AppActivity.ts
+++ b/src/app/AppActivity.ts
@@ -1,7 +1,57 @@
-import { ManagedState, shadowObservable, observe, ComponentConstructor } from "../core";
+import {
+  ManagedState,
+  shadowObservable,
+  observe,
+  ComponentConstructor,
+  ActionEvent,
+  Component,
+} from "../core";
 import type { AppActivationContext } from "./AppActivationContext";
 import type { Application } from "./Application";
 import { AppComponent } from "./AppComponent";
+
+/** Represents a target that can be 'navigated' to, i.e. using `Application.navigate()`. Objects are referenced from any `AppActivity` or from `UIButton` instances, and can be used with `NavigationEvent` events, which are handled by `AppActivity.onNavigate` (by default) to navigate to a given target path. */
+export class NavigationTarget {
+  /** Create a new navigation target for given path or activity; if an activity is provided, the path is taken from its `AppActivity.path` property when requested */
+  constructor(path: string | AppActivity, title?: string | { toString(): string }) {
+    this.title = title;
+    if (path instanceof AppActivity) {
+      this._activity = path;
+      if (title === undefined && path.name) this.title = path.name;
+    } else {
+      this._path = String(path);
+    }
+  }
+
+  /** Optional name of this target, as a string or an object that can be cast to a string (e.g. `I18nString`, the result of `strf`) */
+  title?: string | { toString(): string };
+
+  /** Returns the path that is associated with this target */
+  toString() {
+    let path = String((this._activity ? this._activity.path : this._path) || "");
+    let activity = this._activity;
+    while (activity && path[0] === "." && path[1] === "/") {
+      // replace `./` prefix with parent path, if needed
+      activity = activity.getParentActivity();
+      if (activity instanceof AppActivity && typeof activity.path === "string") {
+        path = activity.path.replace(/\/$/, "") + path.slice(1);
+      }
+    }
+    return path;
+  }
+
+  private _path?: string;
+  private _activity?: AppActivity;
+}
+
+/** An event that causes the app to navigate to a target path, when handled by `AppActivity.onNavigate`. The navigation target is determined by the source component, using its 'getNavigationTarget' method; otherwise this is a regular instance of `ActionEvent` with its `name` property set to 'Navigate' */
+export interface NavigationEvent<
+  T extends Component = Component & {
+    getNavigationTarget?: () => string | NavigationTarget;
+  }
+> extends ActionEvent<T> {
+  name: "Navigate";
+}
 
 /** Activity base class. Represents a component of an application, which can be activated and deactivated independently. Can be used for activities that are activated independently of the UI; otherwise refer to any of the `ViewActivity` classes. Activities are usually preset on the `Application` constructor instead of being constructed independently, except when necessary to facilitate 'lazy' loading of parts of the application code. */
 export class AppActivity extends AppComponent {
@@ -24,6 +74,9 @@ export class AppActivity extends AppComponent {
 
   /** Optional activation path; if set to a string, this activity is automatically activated and deactivated asynchronously, depending on the current target path (e.g. URL path, handled by a platform dependent `AppActivationContext` instance). This string may contain segments such as ':id' or '*name' to capture variable parts of the path; when matched, these parts are stored in the object referenced by the `match` property. */
   path?: string;
+
+  /** Optional navigation target for this activity; only useful if this activity has a direct path (no segments such as ':id' or '*name'). Allows the activity title to be translatable if set to an `I18nString` using e.g. `strf()` */
+  navigationTarget?: NavigationTarget;
 
   /** The path segments that were captured *last* based on the target path, as matched by the `AppActivationContext`, for a path such as `foo/bar/:id`, `foo/*name`, or `./:id`. This property is set when the activity is activated through the `activateAsync` method. */
   @shadowObservable("_matchedPath")
@@ -62,6 +115,14 @@ export class AppActivity extends AppComponent {
 
   /** The timestamp (result of `Date.now()`) corresponding to the moment this activity was last deactivated; or undefined if this activity has never been deactivated. */
   deactivated?: number;
+
+  /** Handle navigation events (emitted by e.g. `UIButton`) by navigating to a corresponding path using `Application.navigate()`; should be overridden if non-standard navigation behavior is required, for e.g. master-detail navigation; requires events to be delegated for components that may emit 'Navigate' events such as nested views and activities */
+  onNavigate(e: NavigationEvent) {
+    if (this.isActive()) {
+      let path = String(e.source.getNavigationTarget?.() || "");
+      if (path) this.getApplication()?.navigate(path);
+    }
+  }
 
   private _matchedPath?: Readonly<AppActivationContext.MatchedPath>;
 

--- a/src/app/Application.ts
+++ b/src/app/Application.ts
@@ -9,8 +9,11 @@ import {
   delegateEvents,
 } from "../core";
 import type { UIRenderContext } from "../ui";
-import type { AppActivationContext } from "./AppActivationContext";
-import { AppActivity } from "./AppActivity";
+import type {
+  AppActivationContext,
+  ApplicationNavigationMode,
+} from "./AppActivationContext";
+import { AppActivity, NavigationTarget } from "./AppActivity";
 import { AppActivityList } from "./AppActivityList";
 
 /** Handler that is used for automatic class updates (e.g. hot module reload) */
@@ -140,14 +143,14 @@ export class Application extends Component {
   }
 
   /** Navigate to given (relative) path using the current `Application.activationContext` */
-  navigate(path: string) {
-    if (this.activationContext) this.activationContext.navigate(path);
+  navigate(path: string | NavigationTarget, mode?: ApplicationNavigationMode) {
+    if (this.activationContext) this.activationContext.navigate(String(path), mode);
     return this;
   }
 
   /** Go back to the previous navigation path, if implemented by the current `Application.activationContext` */
   goBack() {
-    if (this.activationContext) this.activationContext.navigate(":back");
+    if (this.activationContext) this.activationContext.navigate("", { back: true });
     return this;
   }
 

--- a/src/ui/controls/UIButton.ts
+++ b/src/ui/controls/UIButton.ts
@@ -1,7 +1,14 @@
+import type { NavigationTarget } from "../../app";
 import { Binding, strf } from "../../core";
 import { Stringable } from "../UIComponent";
 import { UITheme, UIColor } from "../UITheme";
 import { UIControl } from "./UIControl";
+
+// NOTE: button click handlers are defined in the platform package, not here.
+// This is to accomodate special cases like right-click, ctrl-click, etc.
+// The click handler emits a 'Navigate' action event (if the button is not disabled),
+// which is handled by `AppActivity` unless overridden, which uses the
+// getNavigationTarget method defined here.
 
 /** Represents a button component */
 export class UIButton extends UIControl {
@@ -9,8 +16,8 @@ export class UIButton extends UIControl {
     // quietly change 'text' to label to support JSX tag content
     if ("text" in (presets as any)) presets.label = (presets as any).text;
 
-    // use a 'link' role automatically if `navigateTo` is specified
-    if (presets.navigateTo && !presets.accessibleRole) {
+    // use a 'link' role automatically if navigation target is specified
+    if ((presets.navigateTo || presets.navigationTarget) && !presets.accessibleRole) {
       presets.accessibleRole = "link";
     }
     return super.preset(presets);
@@ -71,6 +78,14 @@ export class UIButton extends UIControl {
 
   /** Path to navigate to automatically when clicked, if not blank; use `:back` to go back in history */
   navigateTo?: string;
+
+  /** Navigation target, can be bound to an `AppActivity.navigationTarget` property, if set */
+  navigationTarget?: NavigationTarget;
+
+  /** Returns the navigation target for this button (as a string or `NavigationTarget` instance), if either `navigateTo` or `navigationTarget` properties have been set */
+  getNavigationTarget() {
+    return this.navigationTarget || this.navigateTo;
+  }
 }
 
 /** Shortcut for `UIButton` constructor preset with the `button_primary` named style from the current theme (see `UITheme`) */
@@ -111,6 +126,8 @@ export namespace UIButton {
     iconAfter?: boolean;
     /** Path to navigate to automatically when clicked, if not blank; use `:back` to go back in history */
     navigateTo?: string;
+    /** Navigation target, can be bound to an `AppActivity.navigationTarget` property, if set */
+    navigationTarget?: NavigationTarget;
     /** Set to true to disable keyboard focus for this button */
     disableKeyboardFocus?: boolean;
   }


### PR DESCRIPTION
This PR makes path-based navigation more flexible and robust.

Buttons with `navigateTo` properties no longer immediately navigate to a link, but instead emit a 'Navigate' event. This event is handled by `AppActivity`, which in turns calls `Application.navigate()`. This makes it possible to override the navigation behavior.

Also, `Application.navigate()` now accepts a 'mode' object which makes it possible to a) go back first, and/or b) replace the current path instead of always 'pushing' to the browser history.

All of this is useful for apps that use hierarchical, flat, or master-detail navigation: cases where you want to use path-based navigation (either URL hashes or History API) but don't just want to introduce new history states and pop them off a stack.