### PR TITLE
Fix return types for handler methods

### DIFF
--- a/src/app/AppActivity.ts
+++ b/src/app/AppActivity.ts
@@ -117,7 +117,7 @@ export class AppActivity extends AppComponent {
   deactivated?: number;
 
   /** Handle navigation events (emitted by e.g. `UIButton`) by navigating to a corresponding path using `Application.navigate()`; should be overridden if non-standard navigation behavior is required, for e.g. master-detail navigation; requires events to be delegated for components that may emit 'Navigate' events such as nested views and activities */
-  onNavigate(e: NavigationEvent) {
+  onNavigate(e: NavigationEvent): boolean | void {
     if (this.isActive()) {
       let path = String(e.source.getNavigationTarget?.() || "");
       if (path) this.getApplication()?.navigate(path);

--- a/src/app/ViewActivity.ts
+++ b/src/app/ViewActivity.ts
@@ -123,7 +123,7 @@ export class ViewActivity extends AppActivity implements UIRenderable {
   }
 
   /** Handle FocusIn UI event, remember first/last focused component */
-  protected onFocusIn(e: ComponentEvent) {
+  protected onFocusIn(e: ComponentEvent): boolean | void {
     if (e.source instanceof UIComponent) {
       if (!this.firstFocused) this.firstFocused = e.source;
       this.lastFocused = e.source;
@@ -280,7 +280,7 @@ export class DialogViewActivity extends ViewActivity {
   }
 
   /** Handle CloseModal event by destroying this activity; stops propagation of the event */
-  protected onCloseModal() {
+  protected onCloseModal(): boolean | void {
     this.destroyAsync();
     return true;
   }

--- a/src/ui/UIMenu.ts
+++ b/src/ui/UIMenu.ts
@@ -47,7 +47,7 @@ export class UIMenu extends Component implements UIRenderable {
   }
 
   /** Handle SelectMenuItem events by setting the `selected` property to the key of the selected item, and then propagating the event on this component itself. */
-  protected onSelectMenuItem(e: UIMenuItemSelectedEvent) {
+  protected onSelectMenuItem(e: UIMenuItemSelectedEvent): boolean | void {
     this.selected = e.key;
     this.emit(e);
     return true;

--- a/src/ui/controllers/UIListController.ts
+++ b/src/ui/controllers/UIListController.ts
@@ -82,7 +82,7 @@ export class UIListController extends UIRenderableController<UIContainer> {
   }
 
   /** Handle FocusIn events, saving the index of the focused item or restoring focus on the item that was focused last */
-  protected onFocusIn(e: ComponentEvent) {
+  protected onFocusIn(e: ComponentEvent): boolean | void {
     if (e.source !== this.content) {
       // store focus index
       let idx = this.getIndexOfComponent(e.source);
@@ -95,7 +95,7 @@ export class UIListController extends UIRenderableController<UIContainer> {
   }
 
   /** Handle ArrowUpKeyPress events, focusing the previous list item */
-  protected onArrowUpKeyPress() {
+  protected onArrowUpKeyPress(): boolean | void {
     if (!this.focusPreviousItem()) {
       let parentList = this.getParentComponent(UIListController);
       if (parentList && parentList.enableArrowKeyFocus) {
@@ -107,7 +107,7 @@ export class UIListController extends UIRenderableController<UIContainer> {
   }
 
   /** Handle ArrowDownKeyPress events, focusing the next list item */
-  protected onArrowDownKeyPress() {
+  protected onArrowDownKeyPress(): boolean | void {
     if (!this.focusNextItem()) {
       let parentList = this.getParentComponent(UIListController);
       if (parentList && parentList.enableArrowKeyFocus) {

--- a/src/ui/controllers/UISelectionController.ts
+++ b/src/ui/controllers/UISelectionController.ts
@@ -8,7 +8,7 @@ export class UISelectionController extends UIRenderableController {
   selected?: Component;
 
   /** Handle Select events, remember the (original) source component and deselect the previously selected component, if any */
-  onSelect(e: ComponentEvent) {
+  protected onSelect(e: ComponentEvent): boolean | void {
     if (e.source === this.selected) return;
     while (e.inner instanceof ComponentEvent && e.inner.name === "Select") {
       e = e.inner;
@@ -20,7 +20,7 @@ export class UISelectionController extends UIRenderableController {
   }
 
   /** Handle Deselect events (only if their source is the currently selected component) */
-  onDeselect(e: ComponentEvent) {
+  protected onDeselect(e: ComponentEvent): boolean | void {
     if (e.source === this.selected) this.selected = undefined;
     while (e.inner instanceof ComponentEvent && e.inner.name === "Deselect") {
       e = e.inner;


### PR DESCRIPTION
This PR fixes return types of some handler functions so that it’s easier to override them without resorting to ‘any’.