### PR TITLE
Add auto value to shrinkwrap property

### DIFF
--- a/src/ui/controls/UIButton.ts
+++ b/src/ui/controls/UIButton.ts
@@ -43,7 +43,6 @@ export class UIButton extends UIControl {
   constructor(label?: Stringable) {
     super();
     this.style = UITheme.getStyle("control", "button");
-    this.shrinkwrap = true;
     if (label !== undefined) this.label = label;
   }
 

--- a/src/ui/controls/UIControl.ts
+++ b/src/ui/controls/UIControl.ts
@@ -12,21 +12,23 @@ export abstract class UIControl extends UIComponent {
     let origDecoration: Readonly<UIStyle.Decoration>;
     let origTextStyle: Readonly<UIStyle.TextStyle>;
     if (Binding.isBinding(decoration)) {
-      (this as any).presetBinding("decoration", decoration, function (
-        this: UIControl,
-        v: any
-      ) {
-        this.decoration = v ? { ...origDecoration!, ...v } : origDecoration;
-      });
+      (this as any).presetBinding(
+        "decoration",
+        decoration,
+        function (this: UIControl, v: any) {
+          this.decoration = v ? { ...origDecoration!, ...v } : origDecoration;
+        }
+      );
       decoration = undefined;
     }
     if (Binding.isBinding(textStyle)) {
-      (this as any).presetBinding("textStyle", textStyle, function (
-        this: UIControl,
-        v: any
-      ) {
-        this.textStyle = v ? { ...origTextStyle!, ...v } : origTextStyle;
-      });
+      (this as any).presetBinding(
+        "textStyle",
+        textStyle,
+        function (this: UIControl, v: any) {
+          this.textStyle = v ? { ...origTextStyle!, ...v } : origTextStyle;
+        }
+      );
       textStyle = undefined;
     }
     let f = super.preset(presets);
@@ -55,8 +57,8 @@ export abstract class UIControl extends UIComponent {
   /** Set to true to disable this control */
   disabled?: boolean;
 
-  /** Set to true to shrink this element to use as little space as possible within its container, set to false to expand; defaults to true but may be overridden by individual components, e.g. `UILabel` (also overrides `grow` property of `UIComponent.dimensions`) */
-  shrinkwrap = true;
+  /** Set to true to shrink this element to use as little space as possible within its container, set to false to expand; defaults to true but may be overridden by individual components, e.g. `UIExpandedLabel`. Overrides `grow` property of `UIComponent.dimensions`, unless set to `"auto"`. */
+  shrinkwrap: boolean | "auto" = true;
 }
 
 export namespace UIControl {
@@ -69,7 +71,7 @@ export namespace UIControl {
     /** Disable this control */
     disabled?: boolean;
     /** Shrink or grow this control */
-    shrinkwrap?: boolean;
+    shrinkwrap?: boolean | "auto";
 
     // control element event handlers
     onChange?: UIComponentEventHandler<UIControl>;

--- a/src/ui/controls/UIImage.ts
+++ b/src/ui/controls/UIImage.ts
@@ -20,7 +20,6 @@ export class UIImage extends UIControl {
   constructor(url?: Stringable) {
     super();
     this.style = UITheme.getStyle("control", "image");
-    this.shrinkwrap = true;
     if (url !== undefined) this.url = url;
   }
 

--- a/src/ui/controls/UILabel.ts
+++ b/src/ui/controls/UILabel.ts
@@ -37,7 +37,6 @@ export class UILabel extends UIControl {
   constructor(text?: Stringable) {
     super();
     this.style = UITheme.getStyle("control", "label");
-    this.shrinkwrap = true;
     if (text !== undefined) this.text = text;
   }
 

--- a/src/ui/controls/UISpacer.ts
+++ b/src/ui/controls/UISpacer.ts
@@ -32,7 +32,6 @@ export class UISpacer extends UIControl {
   constructor(width?: string | number, height?: string | number, shrink?: boolean) {
     super();
     this.style = UITheme.getStyle("control", "spacer");
-    this.shrinkwrap = false;
     if (width !== undefined || height !== undefined) {
       this.dimensions = {
         ...this.dimensions,
@@ -41,7 +40,8 @@ export class UISpacer extends UIControl {
         grow: 0,
         shrink: shrink ? 1 : 0,
       };
-      this.shrinkwrap = true;
+    } else {
+      this.shrinkwrap = false;
     }
   }
 }

--- a/src/ui/controls/UIToggle.ts
+++ b/src/ui/controls/UIToggle.ts
@@ -21,7 +21,6 @@ export class UIToggle extends UIControl {
   constructor() {
     super();
     this.style = UITheme.getStyle("control", "toggle");
-    this.shrinkwrap = true;
   }
 
   isFocusable() {


### PR DESCRIPTION
Changing the type of `UIControl.shrinkwrap` to `boolean | "auto"` where the 'auto' value should NOT override `UIControl.dimensions.grow` at all. Previously there was no way to achieve this and the control always ended up with a CSS override for `flex-grow` to change the value from the applied style.

Now it's possible to set the grow/shrink values properly in the style, as long as `shrinkwrap` is set to 'auto'.