### PR TITLE
Fix change events after form validation

### DIFF
--- a/src/ui/UIFormContext.ts
+++ b/src/ui/UIFormContext.ts
@@ -61,11 +61,16 @@ export class UIFormContext<TData = any> extends Component {
       if (validate) this.validate(name);
       if (!silent) this.emit(this._changeEvent);
     } else if (validate) {
+      let hadError = !!this.errors[name];
       this.validate(name);
+      let hasError = !!this.errors[name];
+      if (!silent && (hadError || hasError)) {
+        this.emit(this._changeEvent);
+      }
     }
   }
 
-  /** Remove the value for a field with given name, including any associated error, and emit a change event. The field will also no longer be validated. */
+  /** Remove the value for a field with given name, including any associated error, and emit a change event. */
   unset(name: keyof TData) {
     if (!name || !(name in this._values)) return;
     delete this._values[name];
@@ -73,12 +78,10 @@ export class UIFormContext<TData = any> extends Component {
     this.emit(this._changeEvent);
   }
 
-  /** Remove all field values from this instance, including any associated errors, and emit a change event. None of the existing fields will be validated anymore, until they are set again (using `set()`). */
+  /** Remove all field values from this instance, including any associated errors, and emit a change event */
   clear() {
-    for (let p in this._values) {
-      delete this._values[p];
-      delete this.errors[p];
-    }
+    this._values = Object.create(null);
+    for (let p in this.errors) delete this.errors[p];
     this.emit(this._changeEvent);
   }
 
@@ -109,7 +112,7 @@ export class UIFormContext<TData = any> extends Component {
     let value = this._values[name];
     if (this._validations[name]) {
       try {
-        let test = new UIFormContext.ValidationTest(name as string, value);
+        let test = new UIFormContext.ValidationTest<any>(name as string, value);
         this._validations[name](test);
         this.errors[name] = undefined;
       } catch (err) {
@@ -123,7 +126,7 @@ export class UIFormContext<TData = any> extends Component {
 
   /** Validate the current values of all fields that have been set; updates the `error` object, but does _not_ emit a change event */
   validateAll() {
-    for (let p in this._values) this.validate(p);
+    for (let p in this._validations) this.validate(p);
     return this;
   }
 
@@ -154,8 +157,10 @@ export class UIFormContext<TData = any> extends Component {
   readonly errors: { [name in keyof TData]: Error | undefined } = Object.create(null);
 
   private _values: Partial<TData> = Object.create(null);
-  private _validations: any = Object.create(null);
-  private _changeEvent = new UIFormContextChangeEvent(this).freeze();
+  private _validations: {
+    [name in keyof TData]: (test: UIFormContext.ValidationTest<TData[name]>) => void;
+  } = Object.create(null);
+  private _changeEvent = new UIFormContextChangeEvent(this as any).freeze();
 }
 
 export namespace UIFormContext {


### PR DESCRIPTION
Change events after form validation were not working properly, if the value had not changed. Notably, after calls to onInput (not validated) and then onChange (validated) from text fields, a change event would not happen since the values for both calls were the same; however only the last call would validate.