### PR TITLE
Add modal view placement and modal view activity

### DIFF
--- a/src/ui/UIRenderContext.ts
+++ b/src/ui/UIRenderContext.ts
@@ -12,6 +12,7 @@ export const viewportContextBinding = bind("renderContext.viewportContext");
 export enum UIRenderPlacement {
   NONE,
   PAGE,
+  MODAL,
   DIALOG,
   DRAWER,
   DROPDOWN,

--- a/src/ui/controllers/UIModalController.ts
+++ b/src/ui/controllers/UIModalController.ts
@@ -53,8 +53,8 @@ export class UIModalController extends UIRenderableController {
   @managedChild
   modal?: UIRenderable;
 
-  /** Modal view placement, defaults to Dialog */
-  placement = UIRenderPlacement.DIALOG;
+  /** Modal view placement, defaults to plain modal */
+  placement = UIRenderPlacement.MODAL;
 
   /** Modal backdrop opacity (0-1) */
   modalShadeOpacity?: number;
@@ -117,7 +117,7 @@ export namespace UIModalController {
   export interface Presets {
     /** Modal component constructor (can also be passed as an additional argument to `Component.with`) */
     modal?: UIRenderableConstructor;
-    /** Modal view placement, defaults to Dialog */
+    /** Modal view placement, defaults to plain modal */
     placement?: UIRenderPlacement;
     /** Modal backdrop opacity (0-1), defaults to 0 */
     modalShadeOpacity?: number;


### PR DESCRIPTION
This mostly resolves some confusion where 'modal' and 'dialog' were used interchangeably. Now, 'dialog' is an extension of 'modal'. Modal views are intended to cover the entire page (except margins) and Dialog views are intended to be dimensioned and (vertically) positioned.

- Added `UIRenderPlacement.MODAL` value
- `DialogViewActivity` now extends a new class `ModalViewActivity`
- Added `ViewActivity.showModalAsync` which works like `showDialogAsync` but for generic modal views.